### PR TITLE
Fix for setting vlan to intentionally null when modifying the Wan on device managementInterface

### DIFF
--- a/Meraki.Api/Data/WanSpec.cs
+++ b/Meraki.Api/Data/WanSpec.cs
@@ -59,5 +59,6 @@ public class Wan
 	/// <value>The VLAN that management traffic should be tagged with. Applies whether usingStaticIp is true or false.</value>
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "vlan")]
+	[JsonProperty(NullValueHandling = NullValueHandling.Include)]
 	public int? Vlan { get; set; }
 }


### PR DESCRIPTION
Fix for setting vlan to intentionally null when modifying the Wan on device managementInterface