### PR TITLE
Fixed inconsistent method names.

### DIFF
--- a/Meraki.Api.Test/Networks/Tests.cs
+++ b/Meraki.Api.Test/Networks/Tests.cs
@@ -115,7 +115,7 @@ public class Tests : MerakiClientTest
 				await TestMerakiClient
 					.Networks
 					.Devices
-					.RemoveNetworkDeviceAsync(oldNetwork.Id, new DeviceRemovalRequest { Serial = oldNetworkDevice.Serial })
+					.RemoveNetworkDevicesAsync(oldNetwork.Id, new DeviceRemovalRequest { Serial = oldNetworkDevice.Serial })
 					.ConfigureAwait(false);
 			}
 

--- a/Meraki.Api.Test/Networks/Webhooks/Tests.cs
+++ b/Meraki.Api.Test/Networks/Webhooks/Tests.cs
@@ -16,7 +16,7 @@ public class Tests : MerakiClientTest
 			.Networks
 			.WebHooks
 			.PayloadTemplates
-			.GetNetworksWebhooksPayloadTemplatesAsync(network.Id)
+			.GetNetworkWebhooksPayloadTemplatesAsync(network.Id)
 			.ConfigureAwait(false);
 		result.Should().BeOfType<List<PayloadTemplate>>();
 		result.Should().NotBeNull();

--- a/Meraki.Api.Test/Organizations/Networks/Tests.cs
+++ b/Meraki.Api.Test/Organizations/Networks/Tests.cs
@@ -140,7 +140,7 @@ public class Tests : MerakiClientTest
 				await TestMerakiClient
 					.Networks
 					.Devices
-					.RemoveNetworkDeviceAsync(oldNetwork.Id, new DeviceRemovalRequest { Serial = oldNetworkDevice.Serial })
+					.RemoveNetworkDevicesAsync(oldNetwork.Id, new DeviceRemovalRequest { Serial = oldNetworkDevice.Serial })
 					.ConfigureAwait(false);
 			}
 

--- a/Meraki.Api/Interfaces/General/Networks/INetworksDevices.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksDevices.cs
@@ -33,7 +33,7 @@ public interface INetworksDevices
 	/// <param name="networkId">The network id</param>
 	[ApiOperationId("removeNetworkDevices")]
 	[Post("/networks/{networkId}/devices/remove")]
-	Task RemoveNetworkDeviceAsync(
+	Task RemoveNetworkDevicesAsync(
 		[AliasAs("networkId")] string networkId,
 		[Body] DeviceRemovalRequest deviceRemovalRequest,
 		CancellationToken cancellationToken = default);

--- a/Meraki.Api/Interfaces/General/Networks/INetworksWebhooksPayloadTemplates.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksWebhooksPayloadTemplates.cs
@@ -12,7 +12,7 @@ public interface INetworksWebhooksPayloadTemplates
 	/// <param name="networkId">The network id</param>
 	[ApiOperationId("getNetworkWebhooksPayloadTemplates")]
 	[Get("/networks/{networkId}/webhooks/payloadTemplates")]
-	Task<List<PayloadTemplate>> GetNetworksWebhooksPayloadTemplatesAsync(
+	Task<List<PayloadTemplate>> GetNetworkWebhooksPayloadTemplatesAsync(
 		[AliasAs("networkId")] string networkId,
 		CancellationToken cancellationToken = default);
 
@@ -24,7 +24,7 @@ public interface INetworksWebhooksPayloadTemplates
 	/// <param name="createWebhookPayloadTemplate">Body</param>
 	[ApiOperationId("createNetworkWebhooksPayloadTemplate")]
 	[Post("/networks/{networkId}/webhooks/payloadTemplates")]
-	Task UpdateNetworksWebhooksPayloadTemplatesAsync(
+	Task UpdateNetworkWebhooksPayloadTemplateAsync(
 		[AliasAs("networkId")] string networkId,
 		[Body] List<PayloadTemplate> webhookPayloadTemplates,
 		CancellationToken cancellationToken = default);
@@ -37,7 +37,7 @@ public interface INetworksWebhooksPayloadTemplates
 	/// <param name="payloadTemplateId">The payload template id</param>
 	[ApiOperationId("getNetworkWebhooksPayloadTemplate")]
 	[Get("/networks/{networkId}/webhooks/payloadTemplates/{payloadTemplateId}")]
-	Task<PayloadTemplate> GetNetworksWebhooksPayloadTemplateAsync(
+	Task<PayloadTemplate> GetNetworkWebhooksPayloadTemplateAsync(
 		[AliasAs("networkId")] string networkId,
 		[AliasAs("payloadTemplateId")] string payloadTemplateId,
 		CancellationToken cancellationToken = default);

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsAdaptivePolicyGroups.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsAdaptivePolicyGroups.cs
@@ -65,7 +65,7 @@ public interface IOrganizationsAdaptivePolicyGroups
 	/// <param name="updateOrganizationAdaptivePolicyGroup">Body</param>
 	[ApiOperationId("updateOrganizationAdaptivePolicyGroup")]
 	[Put("/organizations/{organizationId}/adaptivePolicy/groups/{groupId}")]
-	Task<AdaptivePolicyGroup> UpdateOrganizationAdaptivePolicyGroup(
+	Task<AdaptivePolicyGroup> UpdateOrganizationAdaptivePolicyGroupAsync(
 		[AliasAs("organizationId")] string organizationId,
 		[AliasAs("groupId")] string groupId,
 		[Body] AdaptivePolicyGroupCreate updateOrganizationAdaptivePolicyGroup,

--- a/Meraki.Api/Interfaces/Products/CellularGateway/ICellularGatewaySubnetPool.cs
+++ b/Meraki.Api/Interfaces/Products/CellularGateway/ICellularGatewaySubnetPool.cs
@@ -11,7 +11,7 @@ public interface ICellularGatewaySubnetPool
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
 	/// <param name="networkId">The network id</param>
 	[Get("/networks/{networkId}/cellularGateway/subnetPool")]
-	Task<NetworkCellularGatewaySubnetPool> GetNetworkCellularGatewaySettingsSubnetPoolAsync(
+	Task<NetworkCellularGatewaySubnetPool> GetNetworkCellularGatewaySubnetPoolAsync(
 		[AliasAs("networkId")] string networkId,
 		CancellationToken cancellationToken = default
 		);
@@ -23,7 +23,7 @@ public interface ICellularGatewaySubnetPool
 	/// <param name="networkId">The network id</param>
 	/// <param name="updateNetworkCellularGatewaySettingsSubnetPool">Body for updating subnet pool and mask config</param>
 	[Put("/networks/{networkId}/cellularGateway/subnetPool")]
-	Task<NetworkCellularGatewaySubnetPool> UpdateNetworkCellularGatewaySettingsSubnetPoolAsync(
+	Task<NetworkCellularGatewaySubnetPool> UpdateNetworkCellularGatewaySubnetPoolAsync(
 		[AliasAs("networkId")] string networkId,
 		[Body] NetworkCellularGatewaySubnetPoolUpdateRequest updateNetworkCellularGatewaySettingsSubnetPool,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/Products/CellularGateway/ICellularGatewayUplink.cs
+++ b/Meraki.Api/Interfaces/Products/CellularGateway/ICellularGatewayUplink.cs
@@ -11,7 +11,7 @@ public interface ICellularGatewayUplink
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
 	/// <param name="networkId">The network id</param>
 	[Get("/networks/{networkId}/cellularGateway/uplink")]
-	Task<NetworkCellularGatewayUplink> GetNetworkCellularGatewaySettingsUplinkAsync(
+	Task<NetworkCellularGatewayUplink> GetNetworkCellularGatewayUplinkAsync(
 		[AliasAs("networkId")] string networkId,
 		CancellationToken cancellationToken = default
 		);
@@ -23,7 +23,7 @@ public interface ICellularGatewayUplink
 	/// <param name="networkId">The network id</param>
 	/// <param name="updateNetworkCellularGatewaySettingsUplink">Body for updating uplink settings</param>
 	[Put("/networks/{networkId}/cellularGateway/uplink")]
-	Task<NetworkCellularGatewayUplink> UpdateNetworkCellularGatewaySettingsUplinkAsync(
+	Task<NetworkCellularGatewayUplink> UpdateNetworkCellularGatewayUplinkAsync(
 		[AliasAs("networkId")] string networkId,
 		[Body] NetworkCellularGatewayUplink updateNetworkCellularGatewaySettingsUplink,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessSsidsFirewall.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessSsidsFirewall.cs
@@ -37,7 +37,7 @@ public interface IWirelessSsidsFirewall
 	/// <param name="networkId">The network id</param>
 	/// <param name="number">The SSID number</param>
 	[Get("/networks/{networkId}/wireless/ssids/{number}/firewall/l3FirewallRules")]
-	Task<SsidLayer3FirewallRules> GetNetworkSsidL3FirewallRulesAsync(
+	Task<SsidLayer3FirewallRules> GetNetworkWirelessSsidFirewallL3FirewallRulesAsync(
 		[AliasAs("networkId")] string networkId,
 		[AliasAs("number")] string number,
 		CancellationToken cancellationToken = default
@@ -51,7 +51,7 @@ public interface IWirelessSsidsFirewall
 	/// <param name="number">The SSID number</param>
 	/// <param name="updateNetworkSsidL3FirewallRules">Body for updating L3 firewall rules</param>
 	[Put("/networks/{networkId}/wireless/ssids/{number}/firewall/l3FirewallRules")]
-	Task<SsidLayer3FirewallRules> UpdateNetworkSsidL3FirewallRulesAsync(
+	Task<SsidLayer3FirewallRules> UpdateNetworkWirelessSsidFirewallL3FirewallRulesAsync(
 		[AliasAs("networkId")] string networkId,
 		[AliasAs("number")] string number,
 		[Body] SsidLayer3FirewallRules updateNetworkSsidL3FirewallRules,


### PR DESCRIPTION
Updated the following method names to follow naming conventions:

RemoveNetworkDeviceAsync -> RemoveNetworkDevicesAsync
GetNetworksWebhooksPayloadTemplatesAsync -> GetNetworkWebhooksPayloadTemplatesAsync
GetNetworkWebhooksPayloadTemplateAsync -> GetNetworkWebhooksPayloadTemplateAsync
UpdateNetworksWebhooksPayloadTemplatesAsync -> UpdateNetworkWebhooksPayloadTemplateAsync
GetNetworkSsidL3FirewallRulesAsync -> GetNetworkWirelessSsidFirewallL3FirewallRulesAsync
UpdateNetworkSsidL3FirewallRulesAsync -> UpdateNetworkWirelessSsidFirewallL3FirewallRulesAsync
GetNetworkCellularGatewaySettingsUplinkAsync -> GetNetworkCellularGatewayUplinkAsync
UpdateNetworkCellularGatewaySettingsUplinkAsync -> UpdateNetworkCellularGatewayUplinkAsync
GetNetworkCellularGatewaySettingsSubnetPoolAsync -> GetNetworkCellularGatewaySubnetPoolAsync
UpdateNetworkCellularGatewaySettingsSubnetPoolAsync -> UpdateNetworkCellularGatewaySubnetPoolAsync
UpdateOrganizationAdaptivePolicyGroup-> UpdateOrganizationAdaptivePolicyGroupAsync
