### PR TITLE
Updated Agility Pack to the same version as used in Report Magic.

### DIFF
--- a/Meraki.Api/Meraki.Api.csproj
+++ b/Meraki.Api/Meraki.Api.csproj
@@ -36,7 +36,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="HtmlAgilityPack.NetCore" Version="1.5.0.1" />
+		<PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Wrong Agility pack was installed, causing big issues when trying to update the Meraki API in Report Magic. Updated to the same one and the same version (used by this method:  MerakiClient.GetEndOfLifeDetailsAsync).

Please merge into main.