### PR TITLE
Bugfix/organization client search

### DIFF
--- a/Meraki.Api.Test/Organizations/Clients/Tests.cs
+++ b/Meraki.Api.Test/Organizations/Clients/Tests.cs
@@ -1,0 +1,20 @@
+namespace Meraki.Api.Test.Organizations.Clients;
+
+public class Tests : MerakiClientTest
+{
+	public Tests(ITestOutputHelper iTestOutputHelper) : base(iTestOutputHelper)
+	{
+	}
+
+	[Fact]
+	public async Task GetOrganizationClients_Succeeds()
+	{
+		var organizationClientSearch = await TestMerakiClient
+			.Organizations
+			.Clients
+			.GetOrganizationClientsSearchAsync(Configuration.TestOrganizationId, Configuration.TestMac)
+			.ConfigureAwait(false);
+
+		_ = organizationClientSearch.Should().NotBeNull();
+	}
+}

--- a/Meraki.Api/MerakiClient.cs
+++ b/Meraki.Api/MerakiClient.cs
@@ -68,6 +68,7 @@ public partial class MerakiClient : IDisposable
 				BrandingPolicies = RefitFor(Organizations.BrandingPolicies.BrandingPolicies),
 				Priorities = RefitFor(Organizations.BrandingPolicies.Priorities)
 			},
+			Clients = RefitFor(Organizations.Clients),
 			ConfigurationChanges = RefitFor(Organizations.ConfigurationChanges),
 			ConfigTemplates = RefitFor(Organizations.ConfigTemplates),
 			Devices = RefitFor(Organizations.Devices),

--- a/Meraki.Api/Sections/General/Organizations/OrganizationsSection.cs
+++ b/Meraki.Api/Sections/General/Organizations/OrganizationsSection.cs
@@ -13,6 +13,8 @@ public partial class OrganizationsSection
 
 	public IOrganizationsApiRequests ApiRequests { get; internal set; } = null!;
 
+	public IOrganizationsClients Clients { get; internal set; } = null!;
+
 	public IOrganizationsConfigTemplates ConfigTemplates { get; internal set; } = null!;
 
 	public IOrganizationsConfigurationChanges ConfigurationChanges { get; internal set; } = null!;


### PR DESCRIPTION
This will add the ability to use the Get Organization Clients Search endpoint as described [Get Organization Clients Search](https://developer.cisco.com/meraki/api/get-organization-clients-search/).

Code was already in place, it just wasn't included in the MerakiClient and the OrganizationsSection to be called.