### PR TITLE
Added nullable Client object to ChangeLogEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## 1.53.17
+
+- Added nullable Client to ChangeLogEntry.cs to prevent deseralization errors for configurationChanges endpoint
+
 ## 1.53.12
 
 - Reverted FluentAssertions to 7.0.0 due to licensing change

--- a/Meraki.Api/Data/ChangeLogEntry.cs
+++ b/Meraki.Api/Data/ChangeLogEntry.cs
@@ -7,6 +7,13 @@
 public class ChangeLogEntry
 {
 	/// <summary>
+	/// Contains "id" and "type" but all examples show null at the moment and no info in the Meraki API docs so leaving as a nullable object for now to prevent de-serialization errors
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "client")]
+	public object? Client { get; set; }
+
+	/// <summary>
 	/// The Timestamp
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]


### PR DESCRIPTION
Added nullable object "Client" property to ChangeLogEntry.cs entity to prevent deseralization errors during unit tests (and elsewhere where the "GetOrganizationConfigurationChangesAsync") method is used.

**There is no information in the Meraki API about what this should contain (though there are 2 properties "id" (probably an int / string) and type.**

All tests ran on 3 organizations I have access to returned as follows, so I have left Client as a nullable object for now.
"client":{"id":null,"type":null}}

Note: relevant unit test passed with this change, and failed beforehand.