### PR TITLE
Wire up missing organization Refit clients and fix ChannelUtilization route parameter (fixes #337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ﻿# Changelog
 
+## 1.70.42
+
+- Fixed several organization-level Refit clients being left `null` by the `MerakiClient`
+  constructor, which threw `NullReferenceException` on first use
+  (issue [#337](https://github.com/panoramicdata/Meraki.Api/issues/337)):
+  - `Organizations.Summary.SwitchPower`
+  - `Organizations.Appliance.Uplinks.Usage`
+  - `Organizations.Wireless.Devices.Latency`
+  - `Organizations.Wireless.Devices.PacketLoss`
+  - `Organizations.Wireless.Devices.ChannelUtilization`
+- Fixed `IOrganizationsWirelessDevicesChannelUtilization`, which Refit could not build at
+  all: all four methods spelled the parameter `orgnanizationId` while the route templates
+  used `{organizationId}`, so `RestService.For<T>()` threw
+  `ArgumentException: ... has parameter organizationid, but no method parameter matches`.
+  The parameter is now `organizationId` throughout. Callers using named arguments would
+  need to update, but the interface could not be constructed before this fix.
+
 ## 1.70.37
 
 - Surfaced `MerakiClient.Wireless.DataRateHistory.GetNetworkWirelessDataRateHistoryAsync`,

--- a/Meraki.Api.Test/MerakiClientQueryTests.cs
+++ b/Meraki.Api.Test/MerakiClientQueryTests.cs
@@ -17,38 +17,38 @@ public class MerakiClientQueryTests
 	public void BuildRequestUri_PreservesApiV1SegmentAndCombinesPath(string baseAddress, string path, string expected)
 	{
 		var uri = MerakiClient.BuildRequestUri(new Uri(baseAddress), path);
-		uri.AbsoluteUri.Should().Be(expected);
+		_ = uri.AbsoluteUri.Should().Be(expected);
 	}
 
 	[Fact]
 	public void GetNextPageUri_WithRelNext_ReturnsAbsoluteNextUriWithCursor()
 	{
 		using var response = new HttpResponseMessage();
-		response.Headers.TryAddWithoutValidation(
+		_ = response.Headers.TryAddWithoutValidation(
 			"Link",
 			"<https://api.meraki.com/api/v1/organizations/123/devices?perPage=1000&startingAfter=Q2XX>; rel=next");
 
 		var next = MerakiClient.GetNextPageUri(response.Headers);
 
-		next.Should().NotBeNull();
-		System.Web.HttpUtility.ParseQueryString(next!.Query).Get("startingAfter").Should().Be("Q2XX");
+		_ = next.Should().NotBeNull();
+		_ = System.Web.HttpUtility.ParseQueryString(next!.Query).Get("startingAfter").Should().Be("Q2XX");
 	}
 
 	[Fact]
 	public void GetNextPageUri_WithFirstAndPrevButNoNext_ReturnsNull()
 	{
 		using var response = new HttpResponseMessage();
-		response.Headers.TryAddWithoutValidation(
+		_ = response.Headers.TryAddWithoutValidation(
 			"Link",
 			"<https://api.meraki.com/api/v1/x?startingAfter=A>; rel=first, <https://api.meraki.com/api/v1/x?endingBefore=B>; rel=prev");
 
-		MerakiClient.GetNextPageUri(response.Headers).Should().BeNull();
+		_ = MerakiClient.GetNextPageUri(response.Headers).Should().BeNull();
 	}
 
 	[Fact]
 	public void GetNextPageUri_WithNoLinkHeader_ReturnsNull()
 	{
 		using var response = new HttpResponseMessage();
-		MerakiClient.GetNextPageUri(response.Headers).Should().BeNull();
+		_ = MerakiClient.GetNextPageUri(response.Headers).Should().BeNull();
 	}
 }

--- a/Meraki.Api.Test/MerakiClientSectionWiringTests.cs
+++ b/Meraki.Api.Test/MerakiClientSectionWiringTests.cs
@@ -1,0 +1,75 @@
+namespace Meraki.Api.Test;
+
+/// <summary>
+/// Unit tests confirming that the organization-level Refit clients reported in
+/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/337">issue 337</see>
+/// are assigned by the <see cref="MerakiClient"/> constructor. These require no network
+/// and no API key, because the wiring happens entirely in the constructor.
+/// </summary>
+public class MerakiClientSectionWiringTests
+{
+	private static MerakiClient CreateClient()
+		=> new(new MerakiClientOptions
+		{
+			ApiKey = "0000000000000000000000000000000000000000",
+			UserAgent = "Meraki.Api.Test/1.0"
+		});
+
+	[Fact]
+	public void Constructor_SetsOrganizationsSummarySwitchPower()
+	{
+		using var merakiClient = CreateClient();
+
+		_ = merakiClient.Organizations.Summary.SwitchPower.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void Constructor_SetsOrganizationsApplianceUplinksUsage()
+	{
+		using var merakiClient = CreateClient();
+
+		_ = merakiClient.Organizations.Appliance.Uplinks.Usage.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void Constructor_SetsOrganizationsWirelessDevicesLatency()
+	{
+		using var merakiClient = CreateClient();
+
+		_ = merakiClient.Organizations.Wireless.Devices.Latency.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void Constructor_SetsOrganizationsWirelessDevicesPacketLoss()
+	{
+		using var merakiClient = CreateClient();
+
+		_ = merakiClient.Organizations.Wireless.Devices.PacketLoss.Should().NotBeNull();
+	}
+
+	/// <summary>
+	/// This one additionally proves the Refit route/parameter fix: before it, building the
+	/// interface threw ArgumentException because the route placeholder was {organizationId}
+	/// but the method parameter was spelled "orgnanizationId".
+	/// </summary>
+	[Fact]
+	public void Constructor_SetsOrganizationsWirelessDevicesChannelUtilization()
+	{
+		using var merakiClient = CreateClient();
+
+		_ = merakiClient.Organizations.Wireless.Devices.ChannelUtilization.Should().NotBeNull();
+	}
+
+	/// <summary>
+	/// The sections that were previously wired must keep working.
+	/// </summary>
+	[Fact]
+	public void Constructor_StillSetsPreviouslyWiredOrganizationClients()
+	{
+		using var merakiClient = CreateClient();
+
+		_ = merakiClient.Organizations.Summary.Top.Should().NotBeNull();
+		_ = merakiClient.Organizations.SwitchPortsOverview.Should().NotBeNull();
+		_ = merakiClient.Organizations.Uplinks.Should().NotBeNull();
+	}
+}

--- a/Meraki.Api.Test/Networks/Tests.cs
+++ b/Meraki.Api.Test/Networks/Tests.cs
@@ -212,7 +212,7 @@ public class Tests(ITestOutputHelper iTestOutputHelper) : MerakiClientTest(iTest
 		_ = updatedVlan.Should().NotBeNull();
 
 		//--- Claim/Remove device
-		await TestMerakiClient
+		_ = await TestMerakiClient
 			.Networks
 			.Devices
 			.ClaimNetworkDevicesAsync(newNetwork.Id, true, new DeviceClaimRequest { Serials = [Configuration.TestDeviceSerial] }, cancellationToken: CancellationToken);

--- a/Meraki.Api.Test/Organizations/Networks/Tests.cs
+++ b/Meraki.Api.Test/Organizations/Networks/Tests.cs
@@ -230,7 +230,7 @@ public class Tests(ITestOutputHelper iTestOutputHelper) : MerakiClientTest(iTest
 		_ = updatedVlan.Should().NotBeNull();
 
 		//--- Claim/Remove device
-		await TestMerakiClient
+		_ = await TestMerakiClient
 			.Networks
 			.Devices
 			.ClaimNetworkDevicesAsync(newNetwork.Id, true, new DeviceClaimRequest { Serials = [Configuration.TestDeviceSerial] }, cancellationToken: CancellationToken);

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsWirelessDevicesChannelUtilization.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsWirelessDevicesChannelUtilization.cs
@@ -9,48 +9,48 @@ public interface IOrganizationsWirelessDevicesChannelUtilization
 	/// Get average channel utilization for all bands in a network, split by AP
 	/// </summary>
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
-	/// <param name="orgnanizationId"></param>
+	/// <param name="organizationId"></param>
 	/// <param name="cancellationToken"></param>
 	/// <returns></returns>
 	[ApiOperationId("getOrganizationWirelessDevicesChannelUtilizationByDevice")]
 	[Get("/organizations/{organizationId}/wireless/devices/channelUtilization/byDevice")]
-	Task<List<OrganizationWirelessDevicesChannelUtilizationByDeviceItem>> GetOrganizationWirelessDevicesChannelUtilizationsByDeviceAsync(string orgnanizationId, CancellationToken cancellationToken = default);
+	Task<List<OrganizationWirelessDevicesChannelUtilizationByDeviceItem>> GetOrganizationWirelessDevicesChannelUtilizationsByDeviceAsync(string organizationId, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Get average channel utilization across all bands for all networks in the organization
 	/// </summary>
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
-	/// <param name="orgnanizationId"></param>
+	/// <param name="organizationId"></param>
 	/// <param name="networkId"></param>
 	/// <param name="cancellationToken"></param>
 	/// <returns></returns>
 	[ApiOperationId("getOrganizationWirelessDevicesChannelUtilizationByNetwork")]
 	[Get("/organizations/{organizationId}/wireless/devices/channelUtilization/byNetwork")]
-	Task<List<OrganizationWirelessDevicesChannelUtilizationByNetworkItem>> GetOrganizationWirelessDevicesChannelUtilizationsByNetworkAsync(string orgnanizationId, string networkId, CancellationToken cancellationToken = default);
+	Task<List<OrganizationWirelessDevicesChannelUtilizationByNetworkItem>> GetOrganizationWirelessDevicesChannelUtilizationsByNetworkAsync(string organizationId, string networkId, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Get a time-series of average channel utilization for all bands, segmented by device.
 	/// </summary>
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
-	/// <param name="orgnanizationId"></param>
+	/// <param name="organizationId"></param>
 	/// <param name="networkId"></param>
 	/// <param name="interval"></param>
 	/// <param name="cancellationToken"></param>
 	/// <returns></returns>
 	[ApiOperationId("getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval")]
 	[Get("/organizations/{organizationId}/wireless/devices/channelUtilization/history/byDevice/byInterval")]
-	Task<List<OrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalItem>> GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalAsync(string orgnanizationId, string networkId, string interval, CancellationToken cancellationToken = default);
+	Task<List<OrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalItem>> GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalAsync(string organizationId, string networkId, string interval, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Get a time-series of average channel utilization for all bands
 	/// </summary>
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
-	/// <param name="orgnanizationId"></param>
+	/// <param name="organizationId"></param>
 	/// <param name="networkId"></param>
 	/// <param name="interval"></param>
 	/// <param name="cancellationToken"></param>
 	/// <returns></returns>
 	[ApiOperationId("getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval")]
 	[Get("/organizations/{organizationId}/wireless/devices/channelUtilization/history/byNetwork/byInterval")]
-	Task<List<OrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalItem>> GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalAsync(string orgnanizationId, string networkId, string interval, CancellationToken cancellationToken = default);
+	Task<List<OrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalItem>> GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalAsync(string organizationId, string networkId, string interval, CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/MerakiClient.cs
+++ b/Meraki.Api/MerakiClient.cs
@@ -143,6 +143,13 @@ public partial class MerakiClient : IDisposable
 				}
 			},
 			ApiRequests = RefitFor(Organizations.ApiRequests),
+			Appliance = new()
+			{
+				Uplinks = new()
+				{
+					Usage = RefitFor(Organizations.Appliance.Uplinks.Usage)
+				}
+			},
 			ApplianceSecurityEvents = RefitFor(Organizations.ApplianceSecurityEvents),
 			AssuranceAlerts = RefitFor(Organizations.AssuranceAlerts),
 			BrandingPolicies = new()
@@ -239,7 +246,8 @@ public partial class MerakiClient : IDisposable
 			Splash = RefitFor(Organizations.Splash),
 			Summary = new()
 			{
-				Top = RefitFor(Organizations.Summary.Top)
+				Top = RefitFor(Organizations.Summary.Top),
+				SwitchPower = RefitFor(Organizations.Summary.SwitchPower)
 			},
 			Switches = RefitFor(Organizations.Switches),
 			SwitchPortsOverview = RefitFor(Organizations.SwitchPortsOverview),
@@ -250,6 +258,15 @@ public partial class MerakiClient : IDisposable
 				Logs = RefitFor(Organizations.Webhooks.Logs),
 				PayloadTemplates = RefitFor(Organizations.Webhooks.PayloadTemplates),
 				HttpServers = RefitFor(Organizations.Webhooks.HttpServers)
+			},
+			Wireless = new()
+			{
+				Devices = new()
+				{
+					ChannelUtilization = RefitFor(Organizations.Wireless.Devices.ChannelUtilization),
+					Latency = RefitFor(Organizations.Wireless.Devices.Latency),
+					PacketLoss = RefitFor(Organizations.Wireless.Devices.PacketLoss)
+				}
 			}
 		};
 


### PR DESCRIPTION
Fixes #337.

## What was wrong

Two separate defects, both reported in #337.

**1. Organization Refit clients never assigned.** The `MerakiClient` constructor did not assign these, so they were still `null` after construction and threw `NullReferenceException` on first use:

- `Organizations.Summary.SwitchPower`
- `Organizations.Appliance.Uplinks.Usage`
- `Organizations.Wireless.Devices.Latency`
- `Organizations.Wireless.Devices.PacketLoss`
- `Organizations.Wireless.Devices.ChannelUtilization`

`Summary` was initialized with only `Top`, and there was no initializer block at all for `Organizations.Appliance` or `Organizations.Wireless`.

**2. `IOrganizationsWirelessDevicesChannelUtilization` could not be built by Refit.** All four of its methods spelled the parameter `orgnanizationId` while the route templates used `{organizationId}`, so `RestService.For<T>()` threw:

```
ArgumentException: URL /organizations/{organizationId}/wireless/devices/channelUtilization/byDevice
has parameter organizationid, but no method parameter matches
```

This one had to be fixed for the wiring to work, since wiring it up without the fix would throw at `new MerakiClient(...)` for every consumer.

## What changed

- `MerakiClient.cs`: added the `Appliance`, `Summary.SwitchPower` and `Wireless` initializer entries, placed in the existing alphabetical order.
- `IOrganizationsWirelessDevicesChannelUtilization.cs`: parameter renamed to `organizationId` on all four methods, with the matching `<param>` doc tags.
- `MerakiClientSectionWiringTests.cs`: new. Needs no network and no API key, because the wiring happens entirely in the constructor.
- `CHANGELOG.md`: entry under 1.70.42. The version heading is a guess and may need correcting at release.

A second commit fixes 9 pre-existing IDE0058 violations in the test project. `.editorconfig` sets `csharp_style_unused_value_expression_statement_preference = discard_variable`, and these statements discarded their value implicitly. Style only, no behaviour change. Happy to drop that commit if you would rather keep it separate.

## Verification

- `dotnet build Meraki.Api.slnx -c Release`: 0 warnings, 0 errors.
- `dotnet build Meraki.Api.Test -p:EnforceCodeStyleInBuild=true`: 0 warnings, 0 errors (was 9 IDE0058 errors).
- `MerakiClientSectionWiringTests` and `MerakiClientQueryTests`: 14 tests, all pass.
- The exact repro from #337 now prints `False` for all five properties.
- A reflection walk of the whole section tree confirms wired leaves went from 279 to 284 with no other change, so nothing else was affected.

The wider test suite was deliberately not run, since it exercises and mutates a live Meraki organization.

## Scope note

This PR closes the five cases named in #337 and nothing more. A reflection census of the section tree found that **82 further Refit clients and 4 sub-section objects are still left `null`** by the constructor, from the same root cause: the constructor is a hand-maintained initializer mirroring a 134-class section tree, with no test asserting it is complete.

That is raised separately as #357, which also flags two more interfaces carrying the identical `orgnanizationId` typo (`IOrganizationsVpnSiteToSiteIpsec` and `ICameraCustomAnalyticsArtifacts`). They are harmless today only because nothing wires them up, and they will start throwing for everyone the moment the wiring gap is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
