### PR TITLE
Add jitter to 429 back-off, and back off before retrying a timeout (#374, #376)

### DIFF
--- a/Meraki.Api.Test/Client/BackOffJitterTests.cs
+++ b/Meraki.Api.Test/Client/BackOffJitterTests.cs
@@ -1,0 +1,157 @@
+namespace Meraki.Api.Test.Client;
+
+/// <summary>
+/// Tests for AuthenticatedBackingOffHttpClientHandler.ApplyJitter (issue #374).
+///
+/// These are pure unit tests - they construct nothing that talks to Meraki and make no network calls.
+/// The randomness source is injected so that every case here is deterministic.
+/// </summary>
+public class BackOffJitterTests
+{
+	private const int Seed = 12345;
+
+	/// <summary>
+	/// Jitter must never shorten a delay. The delay handed in already honours any Retry-After the
+	/// server supplied, so retrying earlier than the returned value would break the server's contract.
+	/// </summary>
+	[Theory]
+	[InlineData(1.0, 30)]
+	[InlineData(5.0, 30)]
+	[InlineData(0.5, 30)]
+	[InlineData(19.9, 30)]
+	public void ApplyJitter_NeverReturnsLessThanTheInputDelay(double delaySeconds, int maxBackOffDelaySeconds)
+	{
+		var input = TimeSpan.FromSeconds(delaySeconds);
+		var random = new Random(Seed);
+
+		for (var i = 0; i < 1000; i++)
+		{
+			var actual = AuthenticatedBackingOffHttpClientHandler.ApplyJitter(input, maxBackOffDelaySeconds, random);
+			_ = actual.Should().BeGreaterThanOrEqualTo(input);
+		}
+	}
+
+	/// <summary>
+	/// Jitter must never exceed the configured maximum, which is a documented ceiling.
+	/// </summary>
+	[Theory]
+	[InlineData(1.0, 30)]
+	[InlineData(25.0, 30)]
+	[InlineData(29.9, 30)]
+	public void ApplyJitter_NeverExceedsTheConfiguredMaximum(double delaySeconds, int maxBackOffDelaySeconds)
+	{
+		var input = TimeSpan.FromSeconds(delaySeconds);
+		var random = new Random(Seed);
+
+		for (var i = 0; i < 1000; i++)
+		{
+			var actual = AuthenticatedBackingOffHttpClientHandler.ApplyJitter(input, maxBackOffDelaySeconds, random);
+			_ = actual.TotalSeconds.Should().BeLessThanOrEqualTo(maxBackOffDelaySeconds);
+		}
+	}
+
+	/// <summary>
+	/// Jitter must never extend a delay by more than the jitter fraction, currently 50%.
+	/// </summary>
+	[Fact]
+	public void ApplyJitter_ExtendsByNoMoreThanHalf()
+	{
+		var input = TimeSpan.FromSeconds(2);
+		var random = new Random(Seed);
+
+		for (var i = 0; i < 1000; i++)
+		{
+			var actual = AuthenticatedBackingOffHttpClientHandler.ApplyJitter(input, 30, random);
+			_ = actual.TotalSeconds.Should().BeLessThanOrEqualTo(3.0);
+		}
+	}
+
+	/// <summary>
+	/// The whole point of the change: the same input must not always produce the same output, otherwise
+	/// clients throttled together stay in lockstep. This is what issue #374 is about.
+	/// </summary>
+	[Fact]
+	public void ApplyJitter_ProducesDifferentDelaysForTheSameInput()
+	{
+		var input = TimeSpan.FromSeconds(1);
+		var random = new Random(Seed);
+
+		var results = Enumerable
+			.Range(0, 100)
+			.Select(_ => AuthenticatedBackingOffHttpClientHandler.ApplyJitter(input, 30, random).TotalSeconds)
+			.ToList();
+
+		_ = results.Distinct().Count().Should().BeGreaterThan(90,
+			"jitter should spread retries across the window rather than clustering them");
+	}
+
+	/// <summary>
+	/// Documents the deliberate limitation described in ApplyJitter's remarks: at the ceiling there is no
+	/// headroom, so the delay is returned unchanged and clients re-align at the maximum.
+	/// </summary>
+	[Theory]
+	[InlineData(30.0, 30)]
+	[InlineData(45.0, 30)]
+	public void ApplyJitter_ReturnsDelayUnchanged_WhenThereIsNoHeadroomBelowTheMaximum(
+		double delaySeconds,
+		int maxBackOffDelaySeconds)
+	{
+		var input = TimeSpan.FromSeconds(delaySeconds);
+
+		var actual = AuthenticatedBackingOffHttpClientHandler.ApplyJitter(
+			input,
+			maxBackOffDelaySeconds,
+			new Random(Seed));
+
+		_ = actual.Should().Be(input);
+	}
+
+	/// <summary>
+	/// A zero or negative maximum must not produce a negative delay, which Task.Delay would reject.
+	/// MerakiClientOptions.Validate would catch a negative value, but MerakiClient never calls it
+	/// (issue #377), so the guard has to hold here regardless.
+	/// </summary>
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void ApplyJitter_DoesNotProduceANegativeDelay_WhenTheMaximumIsNotPositive(int maxBackOffDelaySeconds)
+	{
+		var input = TimeSpan.FromSeconds(1);
+
+		var actual = AuthenticatedBackingOffHttpClientHandler.ApplyJitter(
+			input,
+			maxBackOffDelaySeconds,
+			new Random(Seed));
+
+		_ = actual.Should().Be(input);
+		_ = actual.TotalSeconds.Should().BeGreaterThanOrEqualTo(0);
+	}
+
+	/// <summary>
+	/// The timeout retry path (issue #376) calls CalculateBackoffDelay with a Retry-After of zero, so
+	/// that the configured back-off factor governs rather than another magic number. This pins the
+	/// resulting delays, which are what a timing-out request will now wait between attempts.
+	/// </summary>
+	[Theory]
+	// Default factor of 1.0: one to any power is one, so a flat one second.
+	[InlineData(1, 1.0, 30, 1.0)]
+	[InlineData(5, 1.0, 30, 1.0)]
+	// A configured factor actually grows, and is capped by the maximum.
+	[InlineData(1, 2.0, 30, 1.0)]
+	[InlineData(3, 2.0, 30, 4.0)]
+	[InlineData(6, 2.0, 30, 30.0)]
+	public void TimeoutRetryDelay_UsesTheConfiguredBackOffFactor(
+		int attemptCount,
+		double backOffDelayFactor,
+		int maxBackOffDelaySeconds,
+		double expectedSeconds)
+	{
+		var actual = AuthenticatedBackingOffHttpClientHandler.CalculateBackoffDelay(
+			attemptCount,
+			retryAfterSeconds: 0,
+			backOffDelayFactor,
+			maxBackOffDelaySeconds);
+
+		_ = actual.TotalSeconds.Should().Be(expectedSeconds);
+	}
+}

--- a/Meraki.Api/AuthenticatedBackingOffHttpClientHandler.cs
+++ b/Meraki.Api/AuthenticatedBackingOffHttpClientHandler.cs
@@ -131,17 +131,31 @@ internal sealed class AuthenticatedBackingOffHttpClientHandler(
 					throw new TimeoutException($"The request timed out after multiple attempts ({_options.MaxAttemptCount}).");
 				}
 
+				// Back off before retrying. A timeout usually means the far end is slow because it is
+				// under load, so returning immediately is the least helpful response available, and it
+				// is the one case where we have already waited HttpClientInnerTimeoutSeconds and so have
+				// the least reason to expect the next attempt to be quicker. Every other retry path in
+				// this method pauses first.
+				//
+				// There is no Retry-After to honour here, so pass zero and let the configured back-off
+				// factor govern, rather than introducing another magic number.
+				var timeoutDelay = ApplyJitter(
+					CalculateBackoffDelay(attemptCount, retryAfterSeconds: 0, _options.BackOffDelayFactor, _options.MaxBackOffDelaySeconds),
+					_options.MaxBackOffDelaySeconds,
+					GetJitterRandom());
+
 				_logger.LogWarning(
-					"{LogPrefix}Timed out after {TimeoutSeconds:N1} seconds on attempt {AttemptCount}/{MaxAttemptCount}. ({Method} - {Url})",
+					"{LogPrefix}Timed out after {TimeoutSeconds:N1} seconds on attempt {AttemptCount}/{MaxAttemptCount} - Waiting {TotalSeconds:N2}s. ({Method} - {Url})",
 					logPrefix,
 					_options.HttpClientInnerTimeoutSeconds,
 					attemptCount,
 					_options.MaxAttemptCount,
+					timeoutDelay.TotalSeconds,
 					request.Method.ToString(),
 					request.RequestUri
 					);
 
-				// Retry immediately
+				await Task.Delay(timeoutDelay, cancellationToken).ConfigureAwait(false);
 				continue;
 			}
 			catch (HttpRequestException ex) when (ex.Message.StartsWith("Network is unreachable", StringComparison.Ordinal))
@@ -252,7 +266,12 @@ internal sealed class AuthenticatedBackingOffHttpClientHandler(
 							retryAfterSeconds = 1;
 						}
 
-						delay = CalculateBackoffDelay(attemptCount, retryAfterSeconds, _options.BackOffDelayFactor, _options.MaxBackOffDelaySeconds);
+						// Jittered so that clients throttled in the same window, which Retry-After actively
+						// aligns, do not all come back at the same instant. See ApplyJitter.
+						delay = ApplyJitter(
+							CalculateBackoffDelay(attemptCount, retryAfterSeconds, _options.BackOffDelayFactor, _options.MaxBackOffDelaySeconds),
+							_options.MaxBackOffDelaySeconds,
+							GetJitterRandom());
 
 #pragma warning disable CA1873 // Avoid potentially expensive logging
 						_logger.LogDebug(
@@ -332,6 +351,63 @@ internal sealed class AuthenticatedBackingOffHttpClientHandler(
 				Statistics.RecordStatusCode(statusCodeInt, (long)_durationStopWatch.Elapsed.TotalMilliseconds, (long)delay.TotalMilliseconds);
 			}
 		}
+	}
+
+	/// <summary>
+	/// The maximum proportion by which <see cref="ApplyJitter"/> may extend a computed back-off delay.
+	/// </summary>
+	private const double JitterFraction = 0.5;
+
+#if NETSTANDARD2_0
+	[ThreadStatic]
+	private static Random? _jitterRandom;
+
+	/// <summary>
+	/// netstandard2.0 has no Random.Shared, and Random is not thread safe, so give each thread its own.
+	/// Seeded from a Guid rather than the clock, because clock-seeded instances created on different
+	/// threads within the same tick produce identical sequences, which would defeat the point of jitter.
+	/// </summary>
+	private static Random GetJitterRandom() => _jitterRandom ??= new Random(Guid.NewGuid().GetHashCode());
+#else
+	private static Random GetJitterRandom() => Random.Shared;
+#endif
+
+	/// <summary>
+	/// Spreads a computed back-off delay by a random amount, so that clients throttled at the same
+	/// moment do not all retry at the same instant.
+	/// <para>
+	/// Meraki's rate limit is per organization and one API key is commonly used by several processes,
+	/// or several replicas of one process, against the same organization. Retry-After makes this worse
+	/// rather than better, because every throttled client is handed the same value and is therefore
+	/// actively aligned by it.
+	/// </para>
+	/// <para>
+	/// Jitter is only ever applied UPWARD. Where the server supplied a Retry-After, the delay passed in
+	/// already honours it, so adding to that delay can never retry earlier than the server asked.
+	/// </para>
+	/// <para>
+	/// Note the limitation at the ceiling: once <paramref name="delay"/> has reached
+	/// <paramref name="maxBackOffDelaySeconds"/> there is no headroom left, and the delay is returned
+	/// unchanged. Clients therefore re-align at the maximum. That is deliberate - keeping the documented
+	/// maximum honoured matters more, and at a 30 second cycle the herd effect is far weaker than at one
+	/// second, which is where the shipped defaults actually put it.
+	/// </para>
+	/// </summary>
+	/// <param name="delay">The delay computed by <see cref="CalculateBackoffDelay"/>.</param>
+	/// <param name="maxBackOffDelaySeconds">The configured ceiling, which jitter must not exceed.</param>
+	/// <param name="random">The randomness source. Injected so that tests can seed it.</param>
+	internal static TimeSpan ApplyJitter(
+		TimeSpan delay,
+		int maxBackOffDelaySeconds,
+		Random random)
+	{
+		var delaySeconds = delay.TotalSeconds;
+		var ceilingSeconds = Math.Min(delaySeconds * (1.0 + JitterFraction), maxBackOffDelaySeconds);
+
+		// Where there is no headroom between the delay and the ceiling, leave the delay alone.
+		return ceilingSeconds <= delaySeconds
+			? delay
+			: TimeSpan.FromSeconds(delaySeconds + (random.NextDouble() * (ceilingSeconds - delaySeconds)));
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes #374
Fixes #376

Both of these change retry **timing only**. Neither touches `MerakiClientOptions` or any public API, so no existing configuration behaves differently beyond when it retries. That is why these two were picked and #375, #377 and #378 were left alone: those three can each break a working deployment on upgrade.

## #374 - jitter

`CalculateBackoffDelay` is fully deterministic, so two clients throttled in the same window wait the same time and retry in the same instant. `Retry-After` makes it worse rather than better, because every throttled client is handed the same value and is therefore actively aligned by it. Meraki's limit is per organization and a single API key is commonly used by several processes, or several replicas of one process, against the same organization.

Added as a **separate `ApplyJitter` method** rather than inside `CalculateBackoffDelay`. That was deliberate: `BackOffDelaysTests` asserts exact equality across 14 cases, and that method is worth keeping pure and predictable. All 14 pass unchanged.

Two properties the implementation guarantees:

- **Jitter is only ever applied upward.** The delay passed in already honours any `Retry-After`, so adding to it can never retry earlier than the server asked.
- **It never exceeds `MaxBackOffDelaySeconds`**, which is a documented ceiling.

`netstandard2.0` has no `Random.Shared`, so there is an `#if` with a `[ThreadStatic]` fallback, seeded from a `Guid` rather than the clock. Clock-seeded `Random` instances created on different threads inside the same tick produce identical sequences, which would have quietly defeated the whole change.

### One known limitation, deliberately accepted

Once the delay reaches `MaxBackOffDelaySeconds` there is no headroom left, so the delay is returned unchanged and clients re-align at the maximum. Honouring the documented ceiling seemed more important, and at a 30 second cycle the herd effect is far weaker than at one second, which is where the shipped defaults actually put it. It is called out in the XML docs and pinned by a test so the behaviour is intentional rather than accidental. Happy to add a downward-jitter fallback if you would rather not have that gap.

## #376 - timeouts no longer retry instantly

The inner-timeout path was the only retry route in `SendAsync` with no delay at all. It looped straight back with `continue`. Every other route pauses first:

| Condition | Delay before this PR |
|---|---|
| Inner timeout expiry | **none** |
| "Network is unreachable" | 1s |
| "Connection reset by peer" | 2s |
| 502 / 503 / 504 | 5s |
| 429 | `Retry-After`, then backed off |

A timeout usually means the far end is slow because it is under load, so hammering it again with no pause is the least helpful response available. It is also the one case where we have already waited `HttpClientInnerTimeoutSeconds` and so have the least reason to expect the next attempt to be quicker.

It now reuses `CalculateBackoffDelay` with a `Retry-After` of zero, so the configured `BackOffDelayFactor` governs rather than introducing another magic number, and the applied delay is included in the existing warning log.

**Impact is small.** With the default 25 second inner timeout inside a 600 second `HttpClient.Timeout` you currently get roughly 24 attempts before the outer timeout ends the request. Adding a one second delay makes that roughly 23.

## Testing

New `BackOffJitterTests` (18 cases), all pure with an injected seeded `Random` - no network, no credentials, nothing constructed that talks to Meraki. `InternalsVisibleTo` was already set, so no reflection needed.

Coverage: jitter never shortens a delay, never exceeds the maximum, never extends by more than the jitter fraction, actually varies for identical input, returns unchanged at the ceiling, never yields a negative delay when the maximum is zero or negative, and the exact delays the timeout path will now use for a range of back-off factors.

Ran `BackOffJitterTests` and `BackOffDelaysTests` together: **32 total, 0 failed**. Library builds clean for both `netstandard2.0` and `net10.0` with `EnforceCodeStyleInBuild`.

### What is not covered, and why

`AuthenticatedBackingOffHttpClientHandler` extends `HttpClientHandler`, so `base.SendAsync` goes straight to the network with no seam to stub. **The retry loop itself cannot be unit tested.** The tests cover the pure delay logic thoroughly, but there is no test proving "a timeout causes a one second wait". Making that testable means converting to a `DelegatingHandler`, which is a much larger change and overlaps #375. Worth noting the asymmetry: `MerakiMcpBackingOffHttpMessageHandler` *is* a `DelegatingHandler` and already has a `StubHttpMessageHandler`, so the newer code is testable and this older code is not.

## Two things deliberately left out

1. **The MCP handler.** `MerakiMcpBackingOffHttpMessageHandler` shares `CalculateBackoffDelay` and would benefit from jitter equally, but it is in-flight work and I did not want to create a conflict. `ApplyJitter` is written so adopting it there is a one-line change.
2. **The 502/503/504 path.** It uses a flat 5 seconds for every client on every attempt, which is arguably worse lockstep than the 429 path. Same one-line fix, but it is outside what #374 describes, so it seemed better raised separately than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
