### PR TITLE
Silence IDE0058 in the MCP tests by discarding unused expression values

### DIFF
--- a/Meraki.Api.Test/Mcp/FakeMerakiMcpSession.cs
+++ b/Meraki.Api.Test/Mcp/FakeMerakiMcpSession.cs
@@ -38,7 +38,7 @@ internal sealed class FakeMerakiMcpSession : IMerakiMcpSession
 
 	public async Task<IReadOnlyList<string>> ListToolNamesAsync(CancellationToken cancellationToken)
 	{
-		Interlocked.Increment(ref _listToolNamesCallCount);
+		_ = Interlocked.Increment(ref _listToolNamesCallCount);
 
 		if (OnListToolNames is not null)
 		{

--- a/Meraki.Api.Test/Mcp/InMemoryMcpServer.cs
+++ b/Meraki.Api.Test/Mcp/InMemoryMcpServer.cs
@@ -100,7 +100,7 @@ internal sealed class InMemoryMcpServer : IClientTransport, ITransport
 
 	public ValueTask DisposeAsync()
 	{
-		_toClient.Writer.TryComplete();
+		_ = _toClient.Writer.TryComplete();
 		return ValueTask.CompletedTask;
 	}
 }

--- a/Meraki.Api.Test/Mcp/McpSdkSessionTests.cs
+++ b/Meraki.Api.Test/Mcp/McpSdkSessionTests.cs
@@ -24,10 +24,10 @@ public class McpSdkSessionTests
 
 		var status = await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		status.IsConnected.Should().BeTrue();
-		status.AvailableToolNames.Should().BeEquivalentTo(
+		_ = status.IsConnected.Should().BeTrue();
+		_ = status.AvailableToolNames.Should().BeEquivalentTo(
 			[MerakiMcpClient.SemanticSearchToolName, MerakiMcpClient.ExecuteApiToolName]);
-		server.ReceivedMethods.Should().Contain("initialize").And.Contain("tools/list");
+		_ = server.ReceivedMethods.Should().Contain("initialize").And.Contain("tools/list");
 	}
 
 	[Fact]
@@ -45,10 +45,10 @@ public class McpSdkSessionTests
 
 		var capabilities = await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		capabilities.Should().ContainSingle();
-		capabilities[0].CapabilityId.Should().Be("getNetworkClients");
-		capabilities[0].Score.Should().Be(0.9);
-		server.ReceivedMethods.Should().Contain("tools/call");
+		_ = capabilities.Should().ContainSingle();
+		_ = capabilities[0].CapabilityId.Should().Be("getNetworkClients");
+		_ = capabilities[0].Score.Should().Be(0.9);
+		_ = server.ReceivedMethods.Should().Contain("tools/call");
 	}
 
 	[Fact]
@@ -70,8 +70,8 @@ public class McpSdkSessionTests
 			new Dictionary<string, object?> { ["networkId"] = "N_1" },
 			TestContext.Current.CancellationToken);
 
-		result.RawJson.Should().Contain("k1");
-		result.Text.Should().Be("human readable");
+		_ = result.RawJson.Should().Contain("k1");
+		_ = result.Text.Should().Be("human readable");
 	}
 
 	[Fact]
@@ -93,7 +93,7 @@ public class McpSdkSessionTests
 
 		var result = await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.Text.Should().Contain("first").And.Contain("second");
+		_ = result.Text.Should().Contain("first").And.Contain("second");
 	}
 
 	[Fact]
@@ -108,8 +108,8 @@ public class McpSdkSessionTests
 
 		var result = await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.Text.Should().BeNull();
-		result.RawJson.Should().BeEmpty();
+		_ = result.Text.Should().BeNull();
+		_ = result.RawJson.Should().BeEmpty();
 	}
 
 	[Fact]
@@ -128,7 +128,7 @@ public class McpSdkSessionTests
 
 		var act = async () => await client.ExecuteApiAsync("getNoSuchThing", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*capability not found*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*capability not found*");
 	}
 
 	[Fact]
@@ -143,7 +143,7 @@ public class McpSdkSessionTests
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
 		var exception = await act.Should().ThrowAsync<MerakiMcpToolNotFoundException>();
-		exception.Which.AvailableToolNames.Should().ContainSingle().Which.Should().Be("meraki_search_v2");
+		_ = exception.Which.AvailableToolNames.Should().ContainSingle().Which.Should().Be("meraki_search_v2");
 	}
 
 	[Fact]
@@ -158,7 +158,7 @@ public class McpSdkSessionTests
 
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>();
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>();
 	}
 
 	[Fact]
@@ -173,6 +173,6 @@ public class McpSdkSessionTests
 
 		var act = async () => await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<ObjectDisposedException>();
+		_ = await act.Should().ThrowAsync<ObjectDisposedException>();
 	}
 }

--- a/Meraki.Api.Test/Mcp/MerakiMcpBackingOffHttpMessageHandlerTests.cs
+++ b/Meraki.Api.Test/Mcp/MerakiMcpBackingOffHttpMessageHandlerTests.cs
@@ -49,12 +49,12 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, Options(), statistics, TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.OK);
 		var authorization = inner.Requests[0].Headers.Authorization;
-		authorization.Should().NotBeNull();
-		authorization!.Scheme.Should().Be("Bearer");
-		authorization.Parameter.Should().Be("super-secret-key");
-		string.Join(" ", inner.Requests[0].Headers.GetValues("User-Agent"))
+		_ = authorization.Should().NotBeNull();
+		_ = authorization!.Scheme.Should().Be("Bearer");
+		_ = authorization.Parameter.Should().Be("super-secret-key");
+		_ = string.Join(" ", inner.Requests[0].Headers.GetValues("User-Agent"))
 			.Should().Be("MerakiClient/1.0 PanoramicData");
 	}
 
@@ -68,7 +68,7 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, options, new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
-		inner.Requests[0].Headers.Contains("User-Agent").Should().BeFalse();
+		_ = inner.Requests[0].Headers.Contains("User-Agent").Should().BeFalse();
 	}
 
 	[Fact]
@@ -78,8 +78,8 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		var act = async () => await SendAsync(inner, Options(), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpAuthenticationException>();
-		inner.SendCount.Should().Be(1);
+		_ = await act.Should().ThrowAsync<MerakiMcpAuthenticationException>();
+		_ = inner.SendCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -89,15 +89,15 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		var act = async () => await SendAsync(inner, Options(), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpAuthorizationException>();
-		inner.SendCount.Should().Be(1);
+		_ = await act.Should().ThrowAsync<MerakiMcpAuthorizationException>();
+		_ = inner.SendCount.Should().Be(1);
 	}
 
 	[Fact]
 	public void UnauthorizedAndForbidden_AreDistinguishedFromOneAnother()
 	{
-		new MerakiMcpAuthenticationException().Message.Should().Contain("401");
-		new MerakiMcpAuthorizationException().Message.Should().Contain("403");
+		_ = new MerakiMcpAuthenticationException().Message.Should().Contain("401");
+		_ = new MerakiMcpAuthorizationException().Message.Should().Contain("403");
 	}
 
 	[Fact]
@@ -111,11 +111,11 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, Options(), statistics, TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		inner.SendCount.Should().Be(2);
-		statistics.RetryCount.Should().Be(1);
-		statistics.Http.StatusCodeCounts.Should().ContainKey(429);
-		statistics.Http.StatusCodeCounts.Should().ContainKey(200);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+		_ = inner.SendCount.Should().Be(2);
+		_ = statistics.RetryCount.Should().Be(1);
+		_ = statistics.Http.StatusCodeCounts.Should().ContainKey(429);
+		_ = statistics.Http.StatusCodeCounts.Should().ContainKey(200);
 	}
 
 	[Fact]
@@ -127,8 +127,8 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, Options(), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		inner.SendCount.Should().Be(2);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+		_ = inner.SendCount.Should().Be(2);
 	}
 
 	[Fact]
@@ -140,8 +140,8 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, Options(), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		inner.SendCount.Should().Be(2);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+		_ = inner.SendCount.Should().Be(2);
 	}
 
 	[Fact]
@@ -155,9 +155,9 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 		var act = async () => await SendAsync(inner, Options(maxAttemptCount: 3), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
 		var exception = await act.Should().ThrowAsync<MerakiMcpRateLimitException>();
-		exception.Which.AttemptCount.Should().Be(3);
-		exception.Which.Message.Should().Contain("10 requests per second per organization");
-		inner.SendCount.Should().Be(3);
+		_ = exception.Which.AttemptCount.Should().Be(3);
+		_ = exception.Which.Message.Should().Contain("10 requests per second per organization");
+		_ = inner.SendCount.Should().Be(3);
 	}
 
 	[Theory]
@@ -177,9 +177,9 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, options, statistics, TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		inner.SendCount.Should().Be(2);
-		statistics.RetryCount.Should().Be(1);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+		_ = inner.SendCount.Should().Be(2);
+		_ = statistics.RetryCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -191,8 +191,8 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, Options(maxAttemptCount: 2), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-		inner.SendCount.Should().Be(2);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+		_ = inner.SendCount.Should().Be(2);
 	}
 
 	[Fact]
@@ -202,8 +202,8 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, Options(), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-		inner.SendCount.Should().Be(1);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+		_ = inner.SendCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -213,8 +213,8 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, Options(), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-		inner.SendCount.Should().Be(1);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+		_ = inner.SendCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -228,8 +228,8 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		using var response = await SendAsync(inner, Options(), statistics, TestContext.Current.CancellationToken);
 
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		statistics.RetryCount.Should().Be(1);
+		_ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+		_ = statistics.RetryCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -241,7 +241,7 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 		var act = async () => await SendAsync(inner, Options(maxAttemptCount: 1), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
 		var exception = await act.Should().ThrowAsync<MerakiMcpTransportException>();
-		exception.Which.Message.Should().Contain("158.115.141.245").And.Contain("allowlisting");
+		_ = exception.Which.Message.Should().Contain("158.115.141.245").And.Contain("allowlisting");
 	}
 
 	[Fact]
@@ -257,7 +257,7 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 			TestContext.Current.CancellationToken);
 
 		var exception = await act.Should().ThrowAsync<MerakiMcpTransportException>();
-		exception.Which.Message.Should().Contain("http://localhost:9999/mcp");
+		_ = exception.Which.Message.Should().Contain("http://localhost:9999/mcp");
 	}
 
 	[Fact]
@@ -269,7 +269,7 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 		var act = async () => await SendAsync(inner, Options(maxAttemptCount: 1), new MerakiMcpClientStatistics(), TestContext.Current.CancellationToken);
 
 		var exception = await act.Should().ThrowAsync<MerakiMcpTransportException>();
-		exception.Which.ToString().Should().NotContain("super-secret-key");
+		_ = exception.Which.ToString().Should().NotContain("super-secret-key");
 	}
 
 	[Fact]
@@ -281,7 +281,7 @@ public class MerakiMcpBackingOffHttpMessageHandlerTests
 
 		var act = async () => await SendAsync(inner, Options(), new MerakiMcpClientStatistics(), cancellationTokenSource.Token);
 
-		await act.Should().ThrowAsync<OperationCanceledException>();
+		_ = await act.Should().ThrowAsync<OperationCanceledException>();
 	}
 
 	[Fact]

--- a/Meraki.Api.Test/Mcp/MerakiMcpClientOptionsTests.cs
+++ b/Meraki.Api.Test/Mcp/MerakiMcpClientOptionsTests.cs
@@ -12,13 +12,13 @@ public class MerakiMcpClientOptionsTests
 	{
 		var options = new MerakiMcpClientOptions();
 
-		options.Transport.Should().Be(MerakiMcpTransport.HostedHttp);
-		options.Uri.Should().Be("https://mcp.meraki.com/mcp");
-		options.ApiRegion.Should().Be(ApiRegion.Default);
-		options.EnforceReadOnlyCapabilityNames.Should().BeTrue();
-		options.JsonMissingMemberHandling.Should().Be(JsonMissingMemberHandling.Ignore);
-		options.Arguments.Should().BeEmpty();
-		options.EnvironmentVariables.Should().BeEmpty();
+		_ = options.Transport.Should().Be(MerakiMcpTransport.HostedHttp);
+		_ = options.Uri.Should().Be("https://mcp.meraki.com/mcp");
+		_ = options.ApiRegion.Should().Be(ApiRegion.Default);
+		_ = options.EnforceReadOnlyCapabilityNames.Should().BeTrue();
+		_ = options.JsonMissingMemberHandling.Should().Be(JsonMissingMemberHandling.Ignore);
+		_ = options.Arguments.Should().BeEmpty();
+		_ = options.EnvironmentVariables.Should().BeEmpty();
 	}
 
 	[Fact]
@@ -26,7 +26,7 @@ public class MerakiMcpClientOptionsTests
 	{
 		var act = () => Valid().Validate();
 
-		act.Should().NotThrow();
+		_ = act.Should().NotThrow();
 	}
 
 	[Theory]
@@ -39,7 +39,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*ApiKey*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*ApiKey*");
 	}
 
 	[Fact]
@@ -50,7 +50,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>()
+		_ = act.Should().Throw<ConfigurationException>()
 			.Which.Message.Should().Contain("LocalHttp").And.Contain("Stdio");
 	}
 
@@ -68,7 +68,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().NotThrow();
+		_ = act.Should().NotThrow();
 	}
 
 	[Theory]
@@ -82,7 +82,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*Uri*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*Uri*");
 	}
 
 	[Fact]
@@ -93,7 +93,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*not a valid absolute URI*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*not a valid absolute URI*");
 	}
 
 	[Fact]
@@ -104,7 +104,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*http or https*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*http or https*");
 	}
 
 	[Fact]
@@ -115,7 +115,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*Command*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*Command*");
 	}
 
 	[Fact]
@@ -128,7 +128,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().NotThrow();
+		_ = act.Should().NotThrow();
 	}
 
 	[Fact]
@@ -139,7 +139,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*not supported*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*not supported*");
 	}
 
 	[Theory]
@@ -152,7 +152,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*HttpClientTimeoutSeconds*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*HttpClientTimeoutSeconds*");
 	}
 
 	[Fact]
@@ -163,7 +163,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*MaxAttemptCount*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*MaxAttemptCount*");
 	}
 
 	[Fact]
@@ -174,7 +174,7 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*MaxBackOffDelaySeconds*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*MaxBackOffDelaySeconds*");
 	}
 
 	[Fact]
@@ -185,6 +185,6 @@ public class MerakiMcpClientOptionsTests
 
 		var act = () => options.Validate();
 
-		act.Should().Throw<ConfigurationException>().WithMessage("*BackOffDelayFactor*");
+		_ = act.Should().Throw<ConfigurationException>().WithMessage("*BackOffDelayFactor*");
 	}
 }

--- a/Meraki.Api.Test/Mcp/MerakiMcpClientTests.cs
+++ b/Meraki.Api.Test/Mcp/MerakiMcpClientTests.cs
@@ -22,7 +22,7 @@ public class MerakiMcpClientTests
 	{
 		var act = () => new MerakiMcpClient(null!);
 
-		act.Should().Throw<ArgumentNullException>();
+		_ = act.Should().Throw<ArgumentNullException>();
 	}
 
 	[Fact]
@@ -30,7 +30,7 @@ public class MerakiMcpClientTests
 	{
 		var act = () => new MerakiMcpClient(new MerakiMcpClientOptions());
 
-		act.Should().Throw<ConfigurationException>();
+		_ = act.Should().Throw<ConfigurationException>();
 	}
 
 	[Fact]
@@ -38,7 +38,7 @@ public class MerakiMcpClientTests
 	{
 		var act = () => new MerakiMcpClient(Options(), null, null!);
 
-		act.Should().Throw<ArgumentNullException>();
+		_ = act.Should().Throw<ArgumentNullException>();
 	}
 
 	// ---------------------------------------------------------------- read-only naming
@@ -80,15 +80,15 @@ public class MerakiMcpClientTests
 
 		var capabilities = await client.SemanticSearchAsync("which clients are on the network?", TestContext.Current.CancellationToken);
 
-		capabilities.Should().HaveCount(2);
-		capabilities[0].CapabilityId.Should().Be("getNetworkClients");
-		capabilities[0].Score.Should().Be(0.93);
-		capabilities[0].Description.Should().Be("List clients");
-		capabilities[0].ParameterSchemaJson.Should().Contain("networkId");
-		capabilities[0].IsReadOperation.Should().BeTrue();
-		capabilities[1].Score.Should().Be(0.71);
-		capabilities[1].Description.Should().BeNull();
-		capabilities[1].ParameterSchemaJson.Should().BeNull();
+		_ = capabilities.Should().HaveCount(2);
+		_ = capabilities[0].CapabilityId.Should().Be("getNetworkClients");
+		_ = capabilities[0].Score.Should().Be(0.93);
+		_ = capabilities[0].Description.Should().Be("List clients");
+		_ = capabilities[0].ParameterSchemaJson.Should().Contain("networkId");
+		_ = capabilities[0].IsReadOperation.Should().BeTrue();
+		_ = capabilities[1].Score.Should().Be(0.71);
+		_ = capabilities[1].Description.Should().BeNull();
+		_ = capabilities[1].ParameterSchemaJson.Should().BeNull();
 	}
 
 	[Fact]
@@ -103,9 +103,9 @@ public class MerakiMcpClientTests
 
 		_ = await client.SemanticSearchAsync("wireless failures", TestContext.Current.CancellationToken);
 
-		session.Calls.Should().ContainSingle();
-		session.Calls[0].ToolName.Should().Be(MerakiMcpClient.SemanticSearchToolName);
-		session.Calls[0].Arguments["query"].Should().Be("wireless failures");
+		_ = session.Calls.Should().ContainSingle();
+		_ = session.Calls[0].ToolName.Should().Be(MerakiMcpClient.SemanticSearchToolName);
+		_ = session.Calls[0].Arguments["query"].Should().Be("wireless failures");
 	}
 
 	[Fact]
@@ -120,7 +120,7 @@ public class MerakiMcpClientTests
 
 		var capabilities = await client.SemanticSearchAsync("device", TestContext.Current.CancellationToken);
 
-		capabilities.Should().ContainSingle().Which.CapabilityId.Should().Be("getDevice");
+		_ = capabilities.Should().ContainSingle().Which.CapabilityId.Should().Be("getDevice");
 	}
 
 	[Theory]
@@ -140,7 +140,7 @@ public class MerakiMcpClientTests
 
 		var capabilities = await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		capabilities.Should().ContainSingle().Which.CapabilityId.Should().Be("getNetworkClients");
+		_ = capabilities.Should().ContainSingle().Which.CapabilityId.Should().Be("getNetworkClients");
 	}
 
 	[Fact]
@@ -158,7 +158,7 @@ public class MerakiMcpClientTests
 
 		var capabilities = await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		capabilities.Should().ContainSingle().Which.CapabilityId.Should().Be("getNetworkClients");
+		_ = capabilities.Should().ContainSingle().Which.CapabilityId.Should().Be("getNetworkClients");
 	}
 
 	[Theory]
@@ -176,7 +176,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*no content*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*no content*");
 	}
 
 	[Fact]
@@ -191,7 +191,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*parse*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*parse*");
 	}
 
 	[Fact]
@@ -206,7 +206,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*capability array*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*capability array*");
 	}
 
 	[Fact]
@@ -221,7 +221,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*no recognisable capabilities*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*no recognisable capabilities*");
 	}
 
 	[Fact]
@@ -236,7 +236,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*quota exceeded*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*quota exceeded*");
 	}
 
 	[Theory]
@@ -249,7 +249,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.SemanticSearchAsync(query!, TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<ArgumentException>();
+		_ = await act.Should().ThrowAsync<ArgumentException>();
 	}
 
 	// ---------------------------------------------------------------- execute api
@@ -269,13 +269,13 @@ public class MerakiMcpClientTests
 			new Dictionary<string, object?> { ["networkId"] = "N_1" },
 			TestContext.Current.CancellationToken);
 
-		result.CapabilityId.Should().Be("getNetworkClients");
-		result.RawJson.Should().Be("""{"clients":[]}""");
-		result.Text.Should().Be("text form");
+		_ = result.CapabilityId.Should().Be("getNetworkClients");
+		_ = result.RawJson.Should().Be("""{"clients":[]}""");
+		_ = result.Text.Should().Be("text form");
 
-		session.Calls[0].ToolName.Should().Be(MerakiMcpClient.ExecuteApiToolName);
-		session.Calls[0].Arguments["capability_id"].Should().Be("getNetworkClients");
-		session.Calls[0].Arguments.Should().ContainKey("parameters");
+		_ = session.Calls[0].ToolName.Should().Be(MerakiMcpClient.ExecuteApiToolName);
+		_ = session.Calls[0].Arguments["capability_id"].Should().Be("getNetworkClients");
+		_ = session.Calls[0].Arguments.Should().ContainKey("parameters");
 	}
 
 	[Fact]
@@ -290,7 +290,7 @@ public class MerakiMcpClientTests
 
 		_ = await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		session.Calls[0].Arguments.Should().NotContainKey("parameters");
+		_ = session.Calls[0].Arguments.Should().NotContainKey("parameters");
 	}
 
 	[Fact]
@@ -305,7 +305,7 @@ public class MerakiMcpClientTests
 
 		_ = await client.ExecuteApiAsync("getOrganizations", new Dictionary<string, object?>(), TestContext.Current.CancellationToken);
 
-		session.Calls[0].Arguments.Should().NotContainKey("parameters");
+		_ = session.Calls[0].Arguments.Should().NotContainKey("parameters");
 	}
 
 	[Fact]
@@ -320,7 +320,7 @@ public class MerakiMcpClientTests
 
 		var result = await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.RawJson.Should().Be("""{"a":1}""");
+		_ = result.RawJson.Should().Be("""{"a":1}""");
 	}
 
 	[Fact]
@@ -335,7 +335,7 @@ public class MerakiMcpClientTests
 
 		var result = await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.RawJson.Should().BeEmpty();
+		_ = result.RawJson.Should().BeEmpty();
 	}
 
 	[Theory]
@@ -352,10 +352,10 @@ public class MerakiMcpClientTests
 		var act = async () => await client.ExecuteApiAsync(capabilityId, cancellationToken: TestContext.Current.CancellationToken);
 
 		var exception = await act.Should().ThrowAsync<MerakiMcpReadOnlyViolationException>();
-		exception.Which.CapabilityId.Should().Be(capabilityId);
-		exception.Which.Message.Should().Contain(nameof(MerakiClient));
+		_ = exception.Which.CapabilityId.Should().Be(capabilityId);
+		_ = exception.Which.Message.Should().Contain(nameof(MerakiClient));
 
-		session.Calls.Should().BeEmpty("the guard must refuse before any call reaches the server");
+		_ = session.Calls.Should().BeEmpty("the guard must refuse before any call reaches the server");
 	}
 
 	[Fact]
@@ -370,7 +370,7 @@ public class MerakiMcpClientTests
 
 		var result = await client.ExecuteApiAsync("updateNetworkSsid", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.CapabilityId.Should().Be("updateNetworkSsid");
+		_ = result.CapabilityId.Should().Be("updateNetworkSsid");
 	}
 
 	[Theory]
@@ -383,7 +383,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync(capabilityId!, cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<ArgumentException>();
+		_ = await act.Should().ThrowAsync<ArgumentException>();
 	}
 
 	[Fact]
@@ -398,7 +398,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getNoSuchThing", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>()
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>()
 			.WithMessage("*getNoSuchThing*unknown capability_id*");
 	}
 
@@ -414,7 +414,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*no detail supplied*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*no detail supplied*");
 	}
 
 	// ---------------------------------------------------------------- payload-level errors
@@ -440,7 +440,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getOrganizationSwitchPortsClientsOverviewByDevice", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>()
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>()
 			.WithMessage("*Missing required parameters*Provide values for: organizationId*");
 	}
 
@@ -459,7 +459,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*Query too long*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*Query too long*");
 	}
 
 	[Fact]
@@ -477,7 +477,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getNoSuchThing", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>()
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>()
 			.WithMessage("*Unknown capability*Run semantic_search first*");
 	}
 
@@ -493,7 +493,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*no detail supplied*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*no detail supplied*");
 	}
 
 	[Theory]
@@ -521,7 +521,7 @@ public class MerakiMcpClientTests
 
 		var result = await client.ExecuteApiAsync("getDevice", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.RawJson.Should().Contain("Q2QN");
+		_ = result.RawJson.Should().Contain("Q2QN");
 	}
 
 	// ---------------------------------------------------------------- envelope unwrapping
@@ -547,11 +547,11 @@ public class MerakiMcpClientTests
 		var result = await client.ExecuteApiAsync("getOrganizationSwitchPortsClientsOverviewByDevice", cancellationToken: TestContext.Current.CancellationToken);
 
 		// The envelope is preserved for anyone who wants it...
-		result.RawJson.Should().Contain("\"type\":\"success\"");
+		_ = result.RawJson.Should().Contain("\"type\":\"success\"");
 
 		// ...but the payload is the data element alone, matching the REST shape.
-		result.DataJson.Should().Be("""{"items":[{"serial":"Q4AA-FWF6-VWK6","model":"MS120-8"}]}""");
-		result.Payload.Should().Be(result.DataJson);
+		_ = result.DataJson.Should().Be("""{"items":[{"serial":"Q4AA-FWF6-VWK6","model":"MS120-8"}]}""");
+		_ = result.Payload.Should().Be(result.DataJson);
 	}
 
 	[Fact]
@@ -569,7 +569,7 @@ public class MerakiMcpClientTests
 
 		var result = await client.ExecuteApiAsync("getDevice", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.Deserialize<DeviceStub>()!.Serial.Should().Be("Q4AA-FWF6-VWK6");
+		_ = result.Deserialize<DeviceStub>()!.Serial.Should().Be("Q4AA-FWF6-VWK6");
 	}
 
 	[Fact]
@@ -584,9 +584,9 @@ public class MerakiMcpClientTests
 
 		var result = await client.ExecuteApiAsync("getDevice", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.DataJson.Should().BeNull();
-		result.Payload.Should().Be(result.RawJson);
-		result.Deserialize<DeviceStub>()!.Serial.Should().Be("Q4AA-FWF6-VWK6");
+		_ = result.DataJson.Should().BeNull();
+		_ = result.Payload.Should().Be(result.RawJson);
+		_ = result.Deserialize<DeviceStub>()!.Serial.Should().Be("Q4AA-FWF6-VWK6");
 	}
 
 	[Fact]
@@ -604,7 +604,7 @@ public class MerakiMcpClientTests
 
 		var result = await client.ExecuteApiAsync("getOrganizationDevices", cancellationToken: TestContext.Current.CancellationToken);
 
-		result.Deserialize<List<DeviceStub>>()!.Should().HaveCount(2);
+		_ = result.Deserialize<List<DeviceStub>>()!.Should().HaveCount(2);
 	}
 
 	[Theory]
@@ -637,9 +637,9 @@ public class MerakiMcpClientTests
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
 		var exception = await act.Should().ThrowAsync<MerakiMcpToolNotFoundException>();
-		exception.Which.ToolName.Should().Be(MerakiMcpClient.SemanticSearchToolName);
-		exception.Which.AvailableToolNames.Should().Contain("something_else");
-		exception.Which.Message.Should().Contain("something_else").And.Contain("beta");
+		_ = exception.Which.ToolName.Should().Be(MerakiMcpClient.SemanticSearchToolName);
+		_ = exception.Which.AvailableToolNames.Should().Contain("something_else");
+		_ = exception.Which.Message.Should().Contain("something_else").And.Contain("beta");
 	}
 
 	[Fact]
@@ -652,7 +652,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpToolNotFoundException>().WithMessage("*none*");
+		_ = await act.Should().ThrowAsync<MerakiMcpToolNotFoundException>().WithMessage("*none*");
 	}
 
 	// ---------------------------------------------------------------- status
@@ -664,24 +664,24 @@ public class MerakiMcpClientTests
 
 		var status = await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		status.IsConnected.Should().BeTrue();
-		status.Message.Should().BeNull();
-		status.AvailableToolNames.Should().Contain(MerakiMcpClient.SemanticSearchToolName);
-		status.ToString().Should().Contain("Connected");
+		_ = status.IsConnected.Should().BeTrue();
+		_ = status.Message.Should().BeNull();
+		_ = status.AvailableToolNames.Should().Contain(MerakiMcpClient.SemanticSearchToolName);
+		_ = status.ToString().Should().Contain("Connected");
 	}
 
 	[Fact]
 	public async Task GetStatusAsync_WhenAToolIsMissing_IsDisconnectedAndSaysWhich()
 	{
 		var session = new FakeMerakiMcpSession();
-		session.ToolNames.Remove(MerakiMcpClient.ExecuteApiToolName);
+		_ = session.ToolNames.Remove(MerakiMcpClient.ExecuteApiToolName);
 
 		using var client = Create(session);
 
 		var status = await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		status.IsConnected.Should().BeFalse();
-		status.Message.Should().Contain(MerakiMcpClient.ExecuteApiToolName);
+		_ = status.IsConnected.Should().BeFalse();
+		_ = status.Message.Should().Contain(MerakiMcpClient.ExecuteApiToolName);
 	}
 
 	[Fact]
@@ -694,8 +694,8 @@ public class MerakiMcpClientTests
 
 		var status = await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		status.IsConnected.Should().BeFalse();
-		status.Message.Should().Contain("none");
+		_ = status.IsConnected.Should().BeFalse();
+		_ = status.Message.Should().Contain("none");
 	}
 
 	[Fact]
@@ -708,9 +708,9 @@ public class MerakiMcpClientTests
 
 		var status = await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		status.IsConnected.Should().BeFalse();
-		status.Message.Should().Contain("no route to host");
-		status.ToString().Should().Contain("Disconnected");
+		_ = status.IsConnected.Should().BeFalse();
+		_ = status.Message.Should().Contain("no route to host");
+		_ = status.ToString().Should().Contain("Disconnected");
 
 		await client.DisposeAsync();
 	}
@@ -727,7 +727,7 @@ public class MerakiMcpClientTests
 
 		var status = await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		status.ToString().Should().NotContain("super-secret-key");
+		_ = status.ToString().Should().NotContain("super-secret-key");
 
 		await client.DisposeAsync();
 	}
@@ -747,7 +747,7 @@ public class MerakiMcpClientTests
 		_ = await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 		_ = await client.ExecuteApiAsync("getNetworks", cancellationToken: TestContext.Current.CancellationToken);
 
-		session.ListToolNamesCallCount.Should().Be(1);
+		_ = session.ListToolNamesCallCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -778,10 +778,10 @@ public class MerakiMcpClientTests
 			.Select(_ => client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken))
 			.ToList();
 
-		await Task.WhenAll(tasks);
+		_ = await Task.WhenAll(tasks);
 
-		sessionCreationCount.Should().Be(1);
-		session.Calls.Should().HaveCount(16);
+		_ = sessionCreationCount.Should().Be(1);
+		_ = session.Calls.Should().HaveCount(16);
 	}
 
 	[Fact]
@@ -804,7 +804,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await task;
 
-		await act.Should().ThrowAsync<OperationCanceledException>();
+		_ = await act.Should().ThrowAsync<OperationCanceledException>();
 	}
 
 	[Fact]
@@ -819,7 +819,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*the SDK exploded*");
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>().WithMessage("*the SDK exploded*");
 	}
 
 	[Fact]
@@ -834,7 +834,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpAuthenticationException>();
+		_ = await act.Should().ThrowAsync<MerakiMcpAuthenticationException>();
 	}
 
 	[Fact]
@@ -851,7 +851,7 @@ public class MerakiMcpClientTests
 
 		var act = async () => await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpAuthorizationException>();
+		_ = await act.Should().ThrowAsync<MerakiMcpAuthorizationException>();
 	}
 
 	[Fact]
@@ -859,7 +859,7 @@ public class MerakiMcpClientTests
 	{
 		var original = new OperationCanceledException("stopped");
 
-		MerakiMcpClient.Translate(new InvalidOperationException("wrapper", original), "testing")
+		_ = MerakiMcpClient.Translate(new InvalidOperationException("wrapper", original), "testing")
 			.Should().BeSameAs(original);
 	}
 
@@ -878,7 +878,7 @@ public class MerakiMcpClientTests
 		_ = await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 		_ = await client.ExecuteApiAsync("getNetworks", cancellationToken: TestContext.Current.CancellationToken);
 
-		client.Statistics.ToolCallCount.Should().Be(2);
+		_ = client.Statistics.ToolCallCount.Should().Be(2);
 	}
 
 	// ---------------------------------------------------------------- disposal
@@ -896,7 +896,7 @@ public class MerakiMcpClientTests
 
 		client.Dispose();
 
-		session.DisposeCount.Should().Be(1);
+		_ = session.DisposeCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -912,7 +912,7 @@ public class MerakiMcpClientTests
 
 		await client.DisposeAsync();
 
-		session.DisposeCount.Should().Be(1);
+		_ = session.DisposeCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -924,7 +924,7 @@ public class MerakiMcpClientTests
 		client.Dispose();
 		client.Dispose();
 
-		session.DisposeCount.Should().Be(0, "no session was ever established");
+		_ = session.DisposeCount.Should().Be(0, "no session was ever established");
 	}
 
 	[Fact]
@@ -941,7 +941,7 @@ public class MerakiMcpClientTests
 		client.Dispose();
 		await client.DisposeAsync();
 
-		session.DisposeCount.Should().Be(1);
+		_ = session.DisposeCount.Should().Be(1);
 	}
 
 	[Fact]
@@ -953,7 +953,7 @@ public class MerakiMcpClientTests
 		await client.DisposeAsync();
 		client.Dispose();
 
-		session.DisposeCount.Should().Be(0);
+		_ = session.DisposeCount.Should().Be(0);
 	}
 
 	[Fact]
@@ -966,8 +966,8 @@ public class MerakiMcpClientTests
 		var execute = async () => await client.ExecuteApiAsync("getOrganizations", cancellationToken: TestContext.Current.CancellationToken);
 		var status = async () => await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		await search.Should().ThrowAsync<ObjectDisposedException>();
-		await execute.Should().ThrowAsync<ObjectDisposedException>();
-		await status.Should().ThrowAsync<ObjectDisposedException>();
+		_ = await search.Should().ThrowAsync<ObjectDisposedException>();
+		_ = await execute.Should().ThrowAsync<ObjectDisposedException>();
+		_ = await status.Should().ThrowAsync<ObjectDisposedException>();
 	}
 }

--- a/Meraki.Api.Test/Mcp/MerakiMcpModelTests.cs
+++ b/Meraki.Api.Test/Mcp/MerakiMcpModelTests.cs
@@ -21,7 +21,7 @@ public class MerakiMcpModelTests
 			RawJson = """{"description":"Laptop"}"""
 		};
 
-		result.Deserialize<Client>()!.Description.Should().Be("Laptop");
+		_ = result.Deserialize<Client>()!.Description.Should().Be("Laptop");
 	}
 
 	[Fact]
@@ -32,7 +32,7 @@ public class MerakiMcpModelTests
 			RawJson = """{"description":"Laptop","somethingCiscoAdded":true}"""
 		};
 
-		result.Deserialize<Client>(JsonMissingMemberHandling.Ignore)!.Description.Should().Be("Laptop");
+		_ = result.Deserialize<Client>(JsonMissingMemberHandling.Ignore)!.Description.Should().Be("Laptop");
 	}
 
 	[Fact]
@@ -46,7 +46,7 @@ public class MerakiMcpModelTests
 
 		var act = () => result.Deserialize<Client>(JsonMissingMemberHandling.ThrowOnError);
 
-		act.Should().Throw<MerakiMcpProtocolException>().WithMessage("*getNetworkClients*");
+		_ = act.Should().Throw<MerakiMcpProtocolException>().WithMessage("*getNetworkClients*");
 	}
 
 	[Theory]
@@ -58,7 +58,7 @@ public class MerakiMcpModelTests
 
 		var act = () => result.Deserialize<Client>();
 
-		act.Should().Throw<MerakiMcpProtocolException>().WithMessage("*no JSON content*");
+		_ = act.Should().Throw<MerakiMcpProtocolException>().WithMessage("*no JSON content*");
 	}
 
 	[Fact]
@@ -68,7 +68,7 @@ public class MerakiMcpModelTests
 
 		var act = () => result.Deserialize<Client>();
 
-		act.Should().Throw<MerakiMcpProtocolException>();
+		_ = act.Should().Throw<MerakiMcpProtocolException>();
 	}
 
 	[Fact]
@@ -94,8 +94,8 @@ public class MerakiMcpModelTests
 	[Fact]
 	public void MerakiCapability_IsReadOperation_ReflectsTheCapabilityName()
 	{
-		new MerakiCapability { CapabilityId = "getNetworkClients" }.IsReadOperation.Should().BeTrue();
-		new MerakiCapability { CapabilityId = "updateNetwork" }.IsReadOperation.Should().BeFalse();
+		_ = new MerakiCapability { CapabilityId = "getNetworkClients" }.IsReadOperation.Should().BeTrue();
+		_ = new MerakiCapability { CapabilityId = "updateNetwork" }.IsReadOperation.Should().BeFalse();
 	}
 
 	// ---------------------------------------------------------------- statistics
@@ -110,17 +110,17 @@ public class MerakiMcpModelTests
 		statistics.RecordRetry(TimeSpan.FromMilliseconds(250));
 		statistics.Http.RecordStatusCode(429, 10, 250);
 
-		statistics.ToolCallCount.Should().Be(2);
-		statistics.RetryCount.Should().Be(1);
-		statistics.TotalBackOffMs.Should().Be(250);
-		statistics.ToString().Should().Contain("Tool calls: 2").And.Contain("Retries: 1");
+		_ = statistics.ToolCallCount.Should().Be(2);
+		_ = statistics.RetryCount.Should().Be(1);
+		_ = statistics.TotalBackOffMs.Should().Be(250);
+		_ = statistics.ToString().Should().Contain("Tool calls: 2").And.Contain("Retries: 1");
 
 		statistics.Reset();
 
-		statistics.ToolCallCount.Should().Be(0);
-		statistics.RetryCount.Should().Be(0);
-		statistics.TotalBackOffMs.Should().Be(0);
-		statistics.Http.TotalRequestCount.Should().Be(0);
+		_ = statistics.ToolCallCount.Should().Be(0);
+		_ = statistics.RetryCount.Should().Be(0);
+		_ = statistics.TotalBackOffMs.Should().Be(0);
+		_ = statistics.Http.TotalRequestCount.Should().Be(0);
 	}
 
 	// ---------------------------------------------------------------- exceptions
@@ -128,35 +128,35 @@ public class MerakiMcpModelTests
 	[Fact]
 	public void Exceptions_ExposeTheStandardConstructors()
 	{
-		new MerakiMcpException().Should().BeOfType<MerakiMcpException>();
-		new MerakiMcpException("message").Message.Should().Be("message");
-		new MerakiMcpException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
+		_ = new MerakiMcpException().Should().BeOfType<MerakiMcpException>();
+		_ = new MerakiMcpException("message").Message.Should().Be("message");
+		_ = new MerakiMcpException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
 
-		new MerakiMcpProtocolException().Should().BeOfType<MerakiMcpProtocolException>();
-		new MerakiMcpProtocolException("message").Message.Should().Be("message");
-		new MerakiMcpProtocolException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
+		_ = new MerakiMcpProtocolException().Should().BeOfType<MerakiMcpProtocolException>();
+		_ = new MerakiMcpProtocolException("message").Message.Should().Be("message");
+		_ = new MerakiMcpProtocolException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
 
-		new MerakiMcpTransportException().Should().BeOfType<MerakiMcpTransportException>();
-		new MerakiMcpTransportException("message").Message.Should().Be("message");
-		new MerakiMcpTransportException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
+		_ = new MerakiMcpTransportException().Should().BeOfType<MerakiMcpTransportException>();
+		_ = new MerakiMcpTransportException("message").Message.Should().Be("message");
+		_ = new MerakiMcpTransportException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
 
-		new MerakiMcpAuthenticationException("message").Message.Should().Be("message");
-		new MerakiMcpAuthenticationException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
+		_ = new MerakiMcpAuthenticationException("message").Message.Should().Be("message");
+		_ = new MerakiMcpAuthenticationException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
 
-		new MerakiMcpAuthorizationException("message").Message.Should().Be("message");
-		new MerakiMcpAuthorizationException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
+		_ = new MerakiMcpAuthorizationException("message").Message.Should().Be("message");
+		_ = new MerakiMcpAuthorizationException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
 
-		new MerakiMcpRateLimitException().Should().BeOfType<MerakiMcpRateLimitException>();
-		new MerakiMcpRateLimitException("message").Message.Should().Be("message");
-		new MerakiMcpRateLimitException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
+		_ = new MerakiMcpRateLimitException().Should().BeOfType<MerakiMcpRateLimitException>();
+		_ = new MerakiMcpRateLimitException("message").Message.Should().Be("message");
+		_ = new MerakiMcpRateLimitException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
 
-		new MerakiMcpToolNotFoundException().Should().BeOfType<MerakiMcpToolNotFoundException>();
-		new MerakiMcpToolNotFoundException("message").Message.Should().Be("message");
-		new MerakiMcpToolNotFoundException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
+		_ = new MerakiMcpToolNotFoundException().Should().BeOfType<MerakiMcpToolNotFoundException>();
+		_ = new MerakiMcpToolNotFoundException("message").Message.Should().Be("message");
+		_ = new MerakiMcpToolNotFoundException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
 
-		new MerakiMcpReadOnlyViolationException().Should().BeOfType<MerakiMcpReadOnlyViolationException>();
-		new MerakiMcpReadOnlyViolationException("message").Message.Should().Be("message");
-		new MerakiMcpReadOnlyViolationException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
+		_ = new MerakiMcpReadOnlyViolationException().Should().BeOfType<MerakiMcpReadOnlyViolationException>();
+		_ = new MerakiMcpReadOnlyViolationException("message").Message.Should().Be("message");
+		_ = new MerakiMcpReadOnlyViolationException("message", new InvalidOperationException()).InnerException.Should().NotBeNull();
 	}
 
 	[Fact]
@@ -164,9 +164,9 @@ public class MerakiMcpModelTests
 	{
 		var exception = new MerakiMcpToolNotFoundException("execute_api", ["semantic_search"]);
 
-		exception.ToolName.Should().Be("execute_api");
-		exception.AvailableToolNames.Should().ContainSingle();
-		exception.Message.Should().Contain("execute_api").And.Contain("semantic_search");
+		_ = exception.ToolName.Should().Be("execute_api");
+		_ = exception.AvailableToolNames.Should().ContainSingle();
+		_ = exception.Message.Should().Contain("execute_api").And.Contain("semantic_search");
 	}
 
 	[Fact]
@@ -174,7 +174,7 @@ public class MerakiMcpModelTests
 	{
 		var exception = MerakiMcpReadOnlyViolationException.ForCapability("updateNetworkSsid");
 
-		exception.CapabilityId.Should().Be("updateNetworkSsid");
-		exception.Message.Should().Contain("updateNetworkSsid").And.Contain(nameof(MerakiClient));
+		_ = exception.CapabilityId.Should().Be("updateNetworkSsid");
+		_ = exception.Message.Should().Contain("updateNetworkSsid").And.Contain(nameof(MerakiClient));
 	}
 }

--- a/Meraki.Api.Test/Mcp/MerakiMcpTransportTests.cs
+++ b/Meraki.Api.Test/Mcp/MerakiMcpTransportTests.cs
@@ -29,9 +29,9 @@ public class MerakiMcpTransportTests
 
 		var status = await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		status.IsConnected.Should().BeFalse();
-		status.Message.Should().NotBeNullOrWhiteSpace();
-		await act.Should().NotThrowAsync("GetStatusAsync reports failures rather than throwing");
+		_ = status.IsConnected.Should().BeFalse();
+		_ = status.Message.Should().NotBeNullOrWhiteSpace();
+		_ = await act.Should().NotThrowAsync("GetStatusAsync reports failures rather than throwing");
 	}
 
 	[Fact]
@@ -40,7 +40,7 @@ public class MerakiMcpTransportTests
 		// Constructing the client must not perform any I/O; the session is created lazily.
 		await using var client = new MerakiMcpClient(new MerakiMcpClientOptions { ApiKey = "key" });
 
-		client.Statistics.ToolCallCount.Should().Be(0);
+		_ = client.Statistics.ToolCallCount.Should().Be(0);
 	}
 
 	[Fact]
@@ -62,7 +62,7 @@ public class MerakiMcpTransportTests
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
 		var exception = await act.Should().ThrowAsync<MerakiMcpTransportException>();
-		exception.Which.Message.Should().Contain("meraki-mcp-command-that-does-not-exist");
+		_ = exception.Which.Message.Should().Contain("meraki-mcp-command-that-does-not-exist");
 	}
 
 	[Fact]
@@ -91,7 +91,7 @@ public class MerakiMcpTransportTests
 
 		var act = async () => await client.SemanticSearchAsync("clients", TestContext.Current.CancellationToken);
 
-		await act.Should().ThrowAsync<MerakiMcpTransportException>();
+		_ = await act.Should().ThrowAsync<MerakiMcpTransportException>();
 	}
 
 	[Fact]
@@ -109,7 +109,7 @@ public class MerakiMcpTransportTests
 
 		var status = await client.GetStatusAsync(TestContext.Current.CancellationToken);
 
-		status.IsConnected.Should().BeFalse();
-		status.Message.Should().Contain("meraki-mcp-command-that-does-not-exist");
+		_ = status.IsConnected.Should().BeFalse();
+		_ = status.Message.Should().Contain("meraki-mcp-command-that-does-not-exist");
 	}
 }

--- a/Meraki.Api.Test/Mcp/StubHttpMessageHandler.cs
+++ b/Meraki.Api.Test/Mcp/StubHttpMessageHandler.cs
@@ -14,7 +14,7 @@ internal sealed class StubHttpMessageHandler : HttpMessageHandler
 
 	public StubHttpMessageHandler EnqueueStatus(System.Net.HttpStatusCode statusCode, string? retryAfter = null)
 	{
-		_responses.Enqueue(_ =>
+		_responses.Enqueue(_request =>
 		{
 			var response = new HttpResponseMessage(statusCode)
 			{
@@ -23,7 +23,7 @@ internal sealed class StubHttpMessageHandler : HttpMessageHandler
 
 			if (retryAfter is not null)
 			{
-				response.Headers.TryAddWithoutValidation("Retry-After", retryAfter);
+				_ = response.Headers.TryAddWithoutValidation("Retry-After", retryAfter);
 			}
 
 			return response;


### PR DESCRIPTION
Cosmetic only. `_ = expr;` is semantically identical to `expr;`, so no test behaviour changes.

The MCP test files were the only ones in the suite not using the `_ =` discard form, so every assertion showed as an IDE0058 "expression value is never used" in the IDE. **218 occurrences across 9 files, and none anywhere else in the test project** — the rest of the suite already uses the discard form over 500 times, so this brings the MCP folder in line rather than introducing a new convention.

Worth noting these never failed a build. `EnforceCodeStyleInBuild` is set on `Meraki.Api` but not on `Meraki.Api.Test`, so in the test project IDE0058 is editor-only analysis. It was purely IDE noise, but enough of it to bury real problems.

## How the locations were found

Taken from the compiler, not matched by regex. Five of the 218 are multi-line chains where `.Should()` begins its own line, for example:

```csharp
string.Join(" ", inner.Requests[0].Headers.GetValues("User-Agent"))
    .Should()
    .Be("...");
```

A text match on `.Should()` would have inserted the discard in the middle of the statement. The compiler reports the statement's start position, which is the correct insertion point. Each point was additionally asserted to be the first non-whitespace character on its line before anything was written.

## One case that needed more than a prefix

`StubHttpMessageHandler.EnqueueStatus` passes a lambda whose parameter is named `_`:

```csharp
_responses.Enqueue(_ =>
{
    ...
    _ = response.Headers.TryAddWithoutValidation("Retry-After", retryAfter);   // CS0029
});
```

Inside that lambda `_` is a bound `HttpRequestMessage`, not a discard, so the prefix tried to assign a `bool` to it. The parameter is renamed to `_request`.

This was the only such case, and the compiler caught it. It is worth flagging that had the types happened to be compatible, it would have compiled silently and quietly reassigned the lambda parameter — which is the sort of thing a regex-driven sweep would have shipped.

## .editorconfig is deliberately unchanged

IDE0058 severity was raised temporarily to enumerate the occurrences and reverted before committing. Making the rule permanently enforced is a separate decision and not one to smuggle into a cleanup PR.

## Verification

- Normal build: **0 warnings, 0 errors**
- Build with `EnforceCodeStyleInBuild=true` and IDE0058 raised: **0 IDE0058 remaining, 0 CS errors**
- **188 tests pass, 0 failed** across `MerakiMcpModelTests`, `MerakiMcpClientOptionsTests`, `MerakiMcpBackingOffHttpMessageHandlerTests`, `McpSdkSessionTests`, `MerakiMcpClientTests`, plus `BackOffJitterTests` and `BackOffDelaysTests`

`MerakiMcpTransportTests` was **not** run. One of its cases constructs a client on the default `Uri`, which is the real `https://mcp.meraki.com/mcp`. It only reads a statistics counter and makes no call, so it is almost certainly offline, but it was skipped rather than assumed. It is included in the diff and compiles clean.

Two unrelated pre-existing style findings surfaced while `EnforceCodeStyleInBuild` was forced on — IDE0046 in `StubHttpMessageHandler` and several IDE0200 in `MerakiMcpClientOptionsTests`. They are untouched here, and do not appear in a normal build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
