### PR TITLE
fix(interfaces): declare optional parameters nullable (fixes #386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ﻿# Changelog
 
+## Unreleased
+
+- Optional parameters across the Refit interfaces are now declared **nullable**: `string? t0 = null`
+  rather than `string t0 = null!` (issue
+  [#386](https://github.com/panoramicdata/Meraki.Api/issues/386)). 194 parameters in 50 interface
+  files, all of them optional query or body parameters where `null` is how a caller omits the value.
+  The old form asserted the opposite of the contract, so a consumer with nullable reference types
+  enabled got a CS8604 at every call site that computed the value - and had no honest way to silence
+  it, because sending an empty string instead is not the same request. Nullability is metadata: no
+  signature, default value or runtime behaviour changed, and the test suite gives identical results
+  before and after.
+
 ## 1.70.57
 
 - Back-off after an HTTP 429 is now **jittered**, so clients sharing an API key that are throttled in

--- a/Meraki.Api/Interfaces/General/Devices/IDeviceClients.cs
+++ b/Meraki.Api/Interfaces/General/Devices/IDeviceClients.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Devices;
+﻿namespace Meraki.Api.Interfaces.General.Devices;
 
 /// <summary>
 /// I Device Clients
@@ -17,7 +17,7 @@ public interface IDeviceClients
 	[Get("/devices/{serial}/clients")]
 	Task<List<DeviceClient>> GetDeviceClientsAsync(
 		string serial,
-		string t0 = null!,
+		string? t0 = null,
 		double? timespan = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Devices/IDeviceLossAndLatencyHistory.cs
+++ b/Meraki.Api/Interfaces/General/Devices/IDeviceLossAndLatencyHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Devices;
+﻿namespace Meraki.Api.Interfaces.General.Devices;
 
 /// <summary>
 /// I Device Loss And Latency History
@@ -22,10 +22,10 @@ public interface IDeviceLossAndLatencyHistory
 	Task<List<LossAndLatencyHistory>> GetDeviceLossAndLatencyHistoryAsync(
 		string serial,
 		string ip,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? resolution = null,
-		string uplink = null!,
+		string? uplink = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksAlertsSettings.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksAlertsSettings.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -28,6 +28,6 @@ public interface INetworksAlertsSettings
 	[Put("/networks/{networkId}/alerts/settings")]
 	Task<NetworkAlertSettings> UpdateNetworkAlertsSettingsAsync(
 		string networkId,
-		[Body] NetworkAlertSettings updateNetworkAlertSettings = null!,
+		[Body] NetworkAlertSettings? updateNetworkAlertSettings = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksBluetoothClients.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksBluetoothClients.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -39,11 +39,11 @@ public interface INetworksBluetoothClients
 	[Get("/networks/{networkId}/bluetoothClients")]
 	Task<List<BluetoothClient>> GetNetworkBluetoothClientsAsync(
 		string networkId,
-		string t0 = null!,
+		string? t0 = null,
 		double? timespan = null,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		bool? includeConnectivityHistory = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksClients.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksClients.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Clients
@@ -30,11 +30,11 @@ public interface INetworksClients
 	[QueryUriFormat(UriFormat.Unescaped)]
 	Task<List<Client>> GetNetworkClientsAsync(
 		string networkId,
-		string t0 = null!,
+		string? t0 = null,
 		double? timespan = null,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		string? statuses = null,
 		string? ip = null,
 		string? ip6 = null,
@@ -51,7 +51,7 @@ public interface INetworksClients
 	[QueryUriFormat(UriFormat.Unescaped)]
 	internal Task<ApiResponse<List<Client>>> GetNetworkClientsApiResponseAsync(
 		string networkId,
-		string t0 = null!,
+		string? t0 = null,
 		double? timespan = null,
 		int? perPage = null,
 		string? startingAfter = null,

--- a/Meraki.Api/Interfaces/General/Networks/INetworksClientsApplicationUsage.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksClientsApplicationUsage.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Clients Application Usage
@@ -23,13 +23,13 @@ public interface INetworksClientsApplicationUsage
 	[Get("/networks/{networkId}/clients/applicationUsage")]
 	Task<List<ApplicationUsage>> GetNetworkClientsApplicationUsageAsync(
 		string networkId,
-		string clients = null!,
+		string? clients = null,
 		int? ssidNumber = null,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
-		string t0 = null!,
-		string t1 = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksClientsBandwidthUsageHistory.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksClientsBandwidthUsageHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Clients Bandwidth Usage History
@@ -22,10 +22,10 @@ public interface INetworksClientsBandwidthUsageHistory
 	Task<List<NetworkClientBandwidthUsageHistory>> GetNetworkClientsBandwidthUsageHistoryAsync(
 		string networkId,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
-		string t0 = null!,
-		string t1 = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksClientsTrafficHistory.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksClientsTrafficHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Clients Traffic History
@@ -21,7 +21,7 @@ public interface INetworksClientsTrafficHistory
 		string networkId,
 		string clientId,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksClientsUsageHistories.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksClientsUsageHistories.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Clients Usage Histories
@@ -23,13 +23,13 @@ public interface INetworksClientsUsageHistories
 	[Get("/networks/{networkId}/clients/usageHistories")]
 	Task<List<ClientApplicationHistory>> GetNetworkClientsUsageHistoriesAsync(
 		string networkId,
-		string clients = null!,
+		string? clients = null,
 		int? ssidNumber = null,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
-		string t0 = null!,
-		string t1 = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksEvents.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksEvents.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Events
@@ -32,23 +32,23 @@ public interface INetworksEvents
 	[Get("/networks/{networkId}/events")]
 	Task<NetworkEvents> GetNetworkEventsAsync(
 		string networkId,
-		string productType = null!,
-		[AliasAs("includedEventTypes[]")] List<string> includedEventTypes = null!,
-		[AliasAs("excludedEventTypes[]")] List<string> excludedEventTypes = null!,
-		string deviceMac = null!,
-		string deviceSerial = null!,
-		string deviceName = null!,
-		string clientIp = null!,
-		string clientMac = null!,
-		string clientName = null!,
-		string smDeviceMac = null!,
-		string smDeviceName = null!,
-		string eventDetails = null!,
-		string eventSeverity = null!,
+		string? productType = null,
+		[AliasAs("includedEventTypes[]")] List<string>? includedEventTypes = null,
+		[AliasAs("excludedEventTypes[]")] List<string>? excludedEventTypes = null,
+		string? deviceMac = null,
+		string? deviceSerial = null,
+		string? deviceName = null,
+		string? clientIp = null,
+		string? clientMac = null,
+		string? clientName = null,
+		string? smDeviceMac = null,
+		string? smDeviceName = null,
+		string? eventDetails = null,
+		string? eventSeverity = null,
 		bool isCatalyst = false,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksHealthChannelUtilization.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksHealthChannelUtilization.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -22,8 +22,8 @@ public interface INetworksHealthChannelUtilization
 	[Get("/networks/{networkId}/networkHealth/channelUtilization")]
 	Task<List<ChannelUtilization>> GetNetworkNetworkHealthChannelUtilizationAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? resolution = null,
 		int? perPage = 100,

--- a/Meraki.Api/Interfaces/General/Networks/INetworksPiiPiiKeys.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksPiiPiiKeys.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Pii Pii Keys
@@ -21,12 +21,12 @@ public interface INetworksPiiPiiKeys
 	[Get("/networks/{networkId}/pii/piiKeys")]
 	Task<PiiKeys> GetNetworkPiiPiiKeysAsync(
 		string networkId,
-		string username = null!,
-		string email = null!,
-		string mac = null!,
-		string serial = null!,
-		string imei = null!,
-		string bluetoothMac = null!,
+		string? username = null,
+		string? email = null,
+		string? mac = null,
+		string? serial = null,
+		string? imei = null,
+		string? bluetoothMac = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksPiiSmDevicesForKey.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksPiiSmDevicesForKey.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Pii Sm Devices For Key
@@ -21,12 +21,12 @@ public interface INetworksPiiSmDevicesForKey
 	[Get("/networks/{networkId}/pii/smDevicesForKey")]
 	Task<PiiSmKeys> GetNetworkPiiSmDevicesForKeyAsync(
 		string networkId,
-		string username = null!,
-		string email = null!,
-		string mac = null!,
-		string serial = null!,
-		string imei = null!,
-		string bluetoothMac = null!,
+		string? username = null,
+		string? email = null,
+		string? mac = null,
+		string? serial = null,
+		string? imei = null,
+		string? bluetoothMac = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksPiiSmOwnersForKey.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksPiiSmOwnersForKey.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Pii Sm Owners For Key
@@ -21,11 +21,11 @@ public interface INetworksPiiSmOwnersForKey
 	[Get("/networks/{networkId}/pii/smOwnersForKey")]
 	Task<PiiSmKeys> GetNetworkPiiSmOwnersForKeyAsync(
 		string networkId,
-		string username = null!,
-		string email = null!,
-		string mac = null!,
-		string serial = null!,
-		string imei = null!,
-		string bluetoothMac = null!,
+		string? username = null,
+		string? email = null,
+		string? mac = null,
+		string? serial = null,
+		string? imei = null,
+		string? bluetoothMac = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksSplashLoginAttempts.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksSplashLoginAttempts.cs
@@ -17,8 +17,8 @@ public interface INetworksSplashLoginAttempts
 	[Get("/networks/{networkId}/splashLoginAttempts")]
 	Task<List<SplashLoginAttempts>> GetNetworkSplashLoginAttemptsAsync(
 		string networkId,
-		string ssidNumber = null!,
-		string loginIdentifier = null!,
+		string? ssidNumber = null,
+		string? loginIdentifier = null,
 		int? timespan = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Networks/INetworksTraffic.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksTraffic.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Networks;
+﻿namespace Meraki.Api.Interfaces.General.Networks;
 
 /// <summary>
 /// I Networks Traffic
@@ -16,9 +16,9 @@ public interface INetworksTraffic
 	[Get("/networks/{networkId}/traffic")]
 	Task<List<NetworkTraffic>> GetNetworkTrafficAsync(
 		string networkId,
-		string t0 = null!,
+		string? t0 = null,
 		double? timespan = null,
-		string deviceType = null!,
+		string? deviceType = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizations.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizations.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Organizations;
+﻿namespace Meraki.Api.Interfaces.General.Organizations;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -16,8 +16,8 @@ public interface IOrganizations
 	[Get("/organizations")]
 	Task<List<Organization>> GetOrganizationsAsync(
 		int? perPage = 9000,
-		string? startingAfter = null!,
-		string? endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default);
 
 	[Get("/organizations")]

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsActionBatches.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsActionBatches.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Organizations;
+﻿namespace Meraki.Api.Interfaces.General.Organizations;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -71,6 +71,6 @@ public interface IOrganizationsActionBatches
 	Task<ActionBatch> UpdateOrganizationActionBatchAsync(
 		string organizationId,
 		string actionBatchId,
-		[Body] ActionBatchUpdateRequest updateOrganizationActionBatch = null!,
+		[Body] ActionBatchUpdateRequest? updateOrganizationActionBatch = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsApiRequests.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsApiRequests.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Organizations;
+﻿namespace Meraki.Api.Interfaces.General.Organizations;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -78,8 +78,8 @@ public interface IOrganizationsApiRequests
 	[Get("/organizations/{organizationId}/apiRequests/overview")]
 	Task<ApiUsageOverview> GetOrganizationApiRequestsOverviewAsync(
 		string organizationId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		CancellationToken cancellationToken = default);
 

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsDevices.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsDevices.cs
@@ -137,11 +137,11 @@ public interface IOrganizationsDevices
 	[Get("/organizations/{organizationId}/devices/uplinksLossAndLatency")]
 	Task<List<UplinksLossAndLatencyResponse>> GetOrganizationDevicesUplinksLossAndLatencyAsync(
 		string organizationId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string uplink = null!,
-		string ip = null!,
+		string? uplink = null,
+		string? ip = null,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -171,9 +171,9 @@ public interface IOrganizationsDevices
 	Task<List<OrganizationDevice>> GetOrganizationDevicesAsync(
 		string organizationId,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
-		string configurationUpdatedAfter = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
+		string? configurationUpdatedAfter = null,
 		[AliasAs("networksIds[]")] List<string>? networksIds = null,
 		[AliasAs("productTypes[]")] List<string>? productTypes = null,
 		[AliasAs("tags[]")] List<string>? tags = null,

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsWebhooksLogs.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsWebhooksLogs.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.General.Organizations;
+﻿namespace Meraki.Api.Interfaces.General.Organizations;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -21,12 +21,12 @@ public interface IOrganizationsWebhooksLogs
 	[Get("/organizations/{organizationId}/webhooks/logs")]
 	Task<List<WebhookLog>> GetOrganizationWebhooksLogsAsync(
 		string organizationId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
-		string url = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
+		string? url = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/Products/Appliance/IApplianceClientsSecurity.cs
+++ b/Meraki.Api/Interfaces/Products/Appliance/IApplianceClientsSecurity.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Appliance;
+﻿namespace Meraki.Api.Interfaces.Products.Appliance;
 
 /// <summary>
 /// I Appliance Clients Security
@@ -22,12 +22,12 @@ public interface IApplianceClientsSecurity
 	Task<List<SecurityEvent>> GetNetworkApplianceClientSecurityEventsAsync(
 		string networkId,
 		string clientId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Appliance/IApplianceSecurityEvents.cs
+++ b/Meraki.Api/Interfaces/Products/Appliance/IApplianceSecurityEvents.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Appliance;
+﻿namespace Meraki.Api.Interfaces.Products.Appliance;
 
 /// <summary>
 /// I Appliance Security Events
@@ -20,12 +20,12 @@ public interface IApplianceSecurityEvents
 	[Get("/networks/{networkId}/appliance/security/events")]
 	Task<List<SecurityEvent>> GetNetworkApplianceSecurityEventsAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Appliance/IApplianceUplinksUsageHistory.cs
+++ b/Meraki.Api/Interfaces/Products/Appliance/IApplianceUplinksUsageHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Appliance;
+﻿namespace Meraki.Api.Interfaces.Products.Appliance;
 
 /// <summary>
 /// I Appliance Uplinks Usage History
@@ -22,8 +22,8 @@ public interface IApplianceUplinksUsageHistory
 	[Get("/networks/{networkId}/appliance/uplinks/usageHistory")]
 	Task<List<UplinkUsageHistory>> GetNetworkApplianceUplinksUsageHistoryAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? resolution = null,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/Products/Camera/ICameraAnalyticsOverview.cs
+++ b/Meraki.Api/Interfaces/Products/Camera/ICameraAnalyticsOverview.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Camera;
+﻿namespace Meraki.Api.Interfaces.Products.Camera;
 
 /// <summary>
 /// I Camera Analytics Overview
@@ -19,10 +19,10 @@ public interface ICameraAnalyticsOverview
 	[Obsolete("This endpoint is deprecated and will be removed in a future update. Please use the new camera/analytics/overview endpoint.", false)]
 	Task<List<CameraOverview>> GetDeviceCameraAnalyticsOverviewAsync(
 		string serial,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string objectType = null!,
+		string? objectType = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Camera/ICameraAnalyticsRecent.cs
+++ b/Meraki.Api/Interfaces/Products/Camera/ICameraAnalyticsRecent.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Camera;
+﻿namespace Meraki.Api.Interfaces.Products.Camera;
 
 /// <summary>
 /// I Camera Analytics Recent
@@ -15,7 +15,7 @@ public interface ICameraAnalyticsRecent
 	[Get("/devices/{serial}/camera/analytics/recent")]
 	Task<List<CameraOverview>> GetDeviceCameraAnalyticsRecentAsync(
 		string serial,
-		string objectType = null!,
+		string? objectType = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Camera/ICameraAnalyticsZones.cs
+++ b/Meraki.Api/Interfaces/Products/Camera/ICameraAnalyticsZones.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Camera;
+﻿namespace Meraki.Api.Interfaces.Products.Camera;
 
 /// <summary>
 /// I Camera Analytics Zones
@@ -21,11 +21,11 @@ public interface ICameraAnalyticsZones
 	Task<List<CameraZoneHistory>> GetDeviceCameraAnalyticsZoneHistoryAsync(
 		string serial,
 		string zoneId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? resolution = null,
-		string objectType = null!,
+		string? objectType = null,
 		CancellationToken cancellationToken = default
 		);
 

--- a/Meraki.Api/Interfaces/Products/Camera/ICameraVideoLink.cs
+++ b/Meraki.Api/Interfaces/Products/Camera/ICameraVideoLink.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Camera;
+﻿namespace Meraki.Api.Interfaces.Products.Camera;
 
 /// <summary>
 /// I Camera Video Link
@@ -15,6 +15,6 @@ public interface ICameraVideoLink
 	[Get("/devices/{serial}/camera/videoLink")]
 	Task<VideoLink> GetDeviceCameraVideoLinkAsync(
 		string serial,
-		string timestamp = null!,
+		string? timestamp = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/Products/Insight/IInsightApplicationHealthByTime.cs
+++ b/Meraki.Api/Interfaces/Products/Insight/IInsightApplicationHealthByTime.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Insight;
+﻿namespace Meraki.Api.Interfaces.Products.Insight;
 
 /// <summary>
 /// I Insight Application Health By Time
@@ -20,8 +20,8 @@ public interface IInsightApplicationHealthByTime
 	Task<List<HealthByTime>> GetNetworkInsightApplicationHealthByTimeAsync(
 		string networkId,
 		string applicationId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? resolution = null,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/Products/Licensing/ILicensingSubscriptions.cs
+++ b/Meraki.Api/Interfaces/Products/Licensing/ILicensingSubscriptions.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Licensing;
+﻿namespace Meraki.Api.Interfaces.Products.Licensing;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -52,15 +52,15 @@ public interface ILicensingSubscriptions
 	[Get("/administered/licensing/subscription/subscriptions")]
 	Task<List<LicensingSubscriptionSubscription>> GetAdministeredLicensingSubscriptionSubscriptionsAsync(
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
-		[AliasAs("subscriptionIds[]")] List<string> subscriptionIds = null!,
-		[AliasAs("organizationIds[]")] List<string> organizationIds = null!,
-		[AliasAs("statuses[]")] List<string> statuses = null!,
-		[AliasAs("productTypes[]")] List<string> productTypes = null!,
-		[AliasAs("skus[]")] List<string> skus = null!,
-		string startDate = null!,
-		string endDate = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
+		[AliasAs("subscriptionIds[]")] List<string>? subscriptionIds = null,
+		[AliasAs("organizationIds[]")] List<string>? organizationIds = null,
+		[AliasAs("statuses[]")] List<string>? statuses = null,
+		[AliasAs("productTypes[]")] List<string>? productTypes = null,
+		[AliasAs("skus[]")] List<string>? skus = null,
+		string? startDate = null,
+		string? endDate = null,
 		CancellationToken cancellationToken = default
 		);
 

--- a/Meraki.Api/Interfaces/Products/Sensor/IOrganizationSensorReadingsHistory.cs
+++ b/Meraki.Api/Interfaces/Products/Sensor/IOrganizationSensorReadingsHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Sensor;
+﻿namespace Meraki.Api.Interfaces.Products.Sensor;
 
 /// <summary>
 /// I Organization Sensor Readings History
@@ -26,8 +26,8 @@ public interface IOrganizationSensorReadingsHistory
 		int? perPage,
 		string? startingAfter = null,
 		string? endingBefore = null,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		[AliasAs("networkIds[]")] List<string>? networkIds = null,
 		[AliasAs("serials[]")] List<string>? serials = null,

--- a/Meraki.Api/Interfaces/Products/Sm/ISmDevices.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmDevices.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Sm;
+﻿namespace Meraki.Api.Interfaces.Products.Sm;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -22,11 +22,11 @@ public interface ISmDevices
 	[Get("/networks/{networkId}/sm/devices")]
 	Task<List<SmDevice>> GetNetworkSmDevicesAsync(
 		string networkId,
-		[AliasAs("fields[]")] List<string> fields = null!,
-		[AliasAs("wifiMacs[]")] List<string> wifiMacs = null!,
-		[AliasAs("serials[]")] List<string> serials = null!,
-		[AliasAs("ids[]")] List<string> ids = null!,
-		[AliasAs("scope[]")] List<string> scope = null!,
+		[AliasAs("fields[]")] List<string>? fields = null,
+		[AliasAs("wifiMacs[]")] List<string>? wifiMacs = null,
+		[AliasAs("serials[]")] List<string>? serials = null,
+		[AliasAs("ids[]")] List<string>? ids = null,
+		[AliasAs("scope[]")] List<string>? scope = null,
 		int? perPage = 1000,
 		string? startingAfter = null,
 		string? endingBefore = null,

--- a/Meraki.Api/Interfaces/Products/Sm/ISmDevicesConnectivity.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmDevicesConnectivity.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Sm;
+﻿namespace Meraki.Api.Interfaces.Products.Sm;
 
 /// <summary>
 /// I Sm Devices Connectivity
@@ -20,8 +20,8 @@ public interface ISmDevicesConnectivity
 		string networkId,
 		string deviceId,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Sm/ISmDevicesDesktopLogs.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmDevicesDesktopLogs.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Sm;
+﻿namespace Meraki.Api.Interfaces.Products.Sm;
 
 /// <summary>
 /// I Sm Devices Desktop Logs
@@ -20,8 +20,8 @@ public interface ISmDevicesDesktopLogs
 		string networkId,
 		string deviceId,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Sm/ISmDevicesDeviceCommandLogs.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmDevicesDeviceCommandLogs.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Sm;
+﻿namespace Meraki.Api.Interfaces.Products.Sm;
 
 /// <summary>
 /// I Sm Devices Device Command Logs
@@ -20,8 +20,8 @@ public interface ISmDevicesDeviceCommandLogs
 		string networkId,
 		string deviceId,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Sm/ISmDevicesPerformanceHistory.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmDevicesPerformanceHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Sm;
+﻿namespace Meraki.Api.Interfaces.Products.Sm;
 
 /// <summary>
 /// I Sm Devices Performance History
@@ -21,8 +21,8 @@ public interface ISmDevicesPerformanceHistory
 		string networkId,
 		string deviceId,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Sm/ISmUserAccessDevices.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmUserAccessDevices.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Sm;
+﻿namespace Meraki.Api.Interfaces.Products.Sm;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -18,8 +18,8 @@ public interface ISmUserAccessDevices
 	Task<List<UserAccessDevices>> GetNetworkSmUserAccessDevicesAsync(
 		string networkId,
 		int? perPage = 1000,
-		string startingAfter = null!,
-		string endingBefore = null!,
+		string? startingAfter = null,
+		string? endingBefore = null,
 		CancellationToken cancellationToken = default
 		);
 

--- a/Meraki.Api/Interfaces/Products/Sm/ISmUsers.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmUsers.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Sm;
+﻿namespace Meraki.Api.Interfaces.Products.Sm;
 
 /// <summary>
 /// I Sm Users
@@ -18,10 +18,10 @@ public interface ISmUsers
 	[Get("/networks/{networkId}/sm/users")]
 	Task<List<SmNetworkUser>> GetNetworkSmUsersAsync(
 		string networkId,
-		string ids = null!,
-		string usernames = null!,
-		string emails = null!,
-		string scope = null!,
+		string? ids = null,
+		string? usernames = null,
+		string? emails = null,
+		string? scope = null,
 		CancellationToken cancellationToken = default
 		);
 }

--- a/Meraki.Api/Interfaces/Products/Switch/ISwitchPorts.cs
+++ b/Meraki.Api/Interfaces/Products/Switch/ISwitchPorts.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Switch;
+﻿namespace Meraki.Api.Interfaces.Products.Switch;
 
 /// <summary>
 /// Represents a collection of functions to interact with the API endpoints
@@ -104,7 +104,7 @@ public interface ISwitchPorts
 	[Get("/devices/{serial}/switch/ports/statuses")]
 	Task<List<SwitchPortStatus>> GetDeviceSwitchPortsStatusesAsync(
 		string serial,
-		string t0 = null!,
+		string? t0 = null,
 		double? timespan = null,
 		CancellationToken cancellationToken = default
 		);
@@ -120,7 +120,7 @@ public interface ISwitchPorts
 	[Get("/devices/{serial}/switch/ports/statuses/packets")]
 	Task<List<PacketsList>> GetDeviceSwitchPortsStatusesPacketsAsync(
 		string serial,
-		string t0 = null!,
+		string? t0 = null,
 		double? timespan = null,
 		CancellationToken cancellationToken = default
 		);

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessAirMarshal.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessAirMarshal.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Air Marshal
@@ -16,7 +16,7 @@ public interface IWirelessAirMarshal
 	[Get("/networks/{networkId}/wireless/airMarshal")]
 	Task<List<AirMarshal>> GetNetworkWirelessAirMarshalAsync(
 		string networkId,
-		string t0 = null!,
+		string? t0 = null,
 		double? timespan = null,
 		CancellationToken cancellationToken = default
 		);

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessChannelUtilizationHistory.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessChannelUtilizationHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Channel Utilization History
@@ -23,8 +23,8 @@ public interface IWirelessChannelUtilizationHistory
 	[Get("/networks/{networkId}/wireless/channelUtilizationHistory")]
 	Task<List<ChannelUtilizationHistory>> GetNetworkWirelessChannelUtilizationHistoryAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? resolution = null,
 		bool? autoResolution = null,

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessClientsConnectionStats.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessClientsConnectionStats.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Clients Connection Stats
@@ -21,13 +21,13 @@ public interface IWirelessClientsConnectionStats
 	[Get("/networks/{networkId}/wireless/clients/connectionStats")]
 	Task<List<NetworkClientConnectionStats>> GetNetworkWirelessClientsConnectionStatsAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
+		string? apTag = null,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -48,12 +48,12 @@ public interface IWirelessClientsConnectionStats
 	Task<NetworkClientConnectionStats> GetNetworkWirelessClientConnectionStatsAsync(
 		string networkId,
 		string clientId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
+		string? apTag = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessClientsLatencyHistory.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessClientsLatencyHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Clients Latency History
@@ -20,8 +20,8 @@ public interface IWirelessClientsLatencyHistory
 	Task<List<ClientLatencyHistory>> GetNetworkWirelessClientLatencyHistoryAsync(
 		string networkId,
 		string clientId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? resolution = null,
 		CancellationToken cancellationToken = default);

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessClientsLatencyStats.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessClientsLatencyStats.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Clients Latency Stats
@@ -22,14 +22,14 @@ public interface IWirelessClientsLatencyStats
 	[Get("/networks/{networkId}/wireless/clients/latencyStats")]
 	Task<List<NetworkClientLatencyStats>> GetNetworkWirelessClientsLatencyStatsAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
-		string fields = null!,
+		string? apTag = null,
+		string? fields = null,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -51,13 +51,13 @@ public interface IWirelessClientsLatencyStats
 	Task<NetworkClientLatencyStats> GetNetworkWirelessClientLatencyStatsAsync(
 		string networkId,
 		string clientId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
-		string fields = null!,
+		string? apTag = null,
+		string? fields = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessConnectionStats.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessConnectionStats.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Connection Stats
@@ -21,13 +21,13 @@ public interface IWirelessConnectionStats
 	[Get("/networks/{networkId}/wireless/connectionStats")]
 	Task<ConnectionStats> GetNetworkWirelessConnectionStatsAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
+		string? apTag = null,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -46,12 +46,12 @@ public interface IWirelessConnectionStats
 	[Get("/devices/{serial}/wireless/connectionStats")]
 	Task<NetworkDeviceConnectionStats> GetDeviceWirelessConnectionStatsAsync(
 		string serial,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
+		string? apTag = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessDeviceConnectionStats.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessDeviceConnectionStats.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Device Connection Stats
@@ -21,12 +21,12 @@ public interface IWirelessDeviceConnectionStats
 	[Get("/networks/{networkId}/wireless/devices/connectionStats")]
 	Task<List<NetworkDeviceConnectionStats>> GetNetworkWirelessDevicesConnectionStatsAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
+		string? apTag = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessDeviceLatencyStats.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessDeviceLatencyStats.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Device Latency Stats
@@ -22,13 +22,13 @@ public interface IWirelessDeviceLatencyStats
 	[Get("/networks/{networkId}/wireless/devices/latencyStats")]
 	Task<List<NetworkDeviceLatencyStats>> GetNetworkWirelessDevicesLatencyStatsAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
-		string fields = null!,
+		string? apTag = null,
+		string? fields = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessFailedConnections.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessFailedConnections.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Failed Connections
@@ -23,14 +23,14 @@ public interface IWirelessFailedConnections
 	[Get("/networks/{networkId}/wireless/failedConnections")]
 	Task<List<FailedConnection>> GetNetworkWirelessFailedConnectionsAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
-		string serial = null!,
-		string clientId = null!,
+		string? apTag = null,
+		string? serial = null,
+		string? clientId = null,
 		CancellationToken cancellationToken = default);
 }

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessLatencyHistory.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessLatencyHistory.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Latency History
@@ -25,8 +25,8 @@ public interface IWirelessLatencyHistory
 	[Get("/networks/{networkId}/wireless/latencyHistory")]
 	Task<List<LatencyHistory>> GetNetworkWirelessLatencyHistoryAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
 		int? resolution = null,
 		bool? autoResolution = null,

--- a/Meraki.Api/Interfaces/Products/Wireless/IWirelessLatencyStats.cs
+++ b/Meraki.Api/Interfaces/Products/Wireless/IWirelessLatencyStats.cs
@@ -1,4 +1,4 @@
-namespace Meraki.Api.Interfaces.Products.Wireless;
+﻿namespace Meraki.Api.Interfaces.Products.Wireless;
 
 /// <summary>
 /// I Wireless Latency Stats
@@ -22,14 +22,14 @@ public interface IWirelessLatencyStats
 	[Get("/devices/{serial}/wireless/latencyStats")]
 	Task<NetworkDeviceLatencyStats> GetDeviceWirelessLatencyStatsAsync(
 		string serial,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
-		string fields = null!,
+		string? apTag = null,
+		string? fields = null,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -49,13 +49,13 @@ public interface IWirelessLatencyStats
 	[Get("/networks/{networkId}/wireless/latencyStats")]
 	Task<LatencyStats> GetNetworkWirelessLatencyStatsAsync(
 		string networkId,
-		string t0 = null!,
-		string t1 = null!,
+		string? t0 = null,
+		string? t1 = null,
 		double? timespan = null,
-		string band = null!,
+		string? band = null,
 		int? ssid = null,
 		int? vlan = null,
-		string apTag = null!,
-		string fields = null!,
+		string? apTag = null,
+		string? fields = null,
 		CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Fixes #386.

## What

194 optional parameters across 50 Refit interface files were declared `string t0 = null!` — non-nullable, with a null-forgiving default. They are now `string? t0 = null`.

```diff
-		string t0 = null!,
+		string? t0 = null,
-		[AliasAs("ids[]")] List<string> ids = null!,
+		[AliasAs("ids[]")] List<string>? ids = null,
```

Breakdown: 178 `string`, 12 `[AliasAs("x[]")] List<string>`, 2 already-nullable `string?` that only carried the redundant `!`, and 2 `[Body]` request types.

## Why

`null` is how a caller omits an optional query or body parameter, so the old form asserted the opposite of the contract. It is invisible inside this repository and expensive outside it: a consumer with nullable reference types enabled gets a CS8604 at every call site that computes the value, and has no honest way to silence it, because sending an empty string is a different request.

In Magic Suite this accounted for **25 warnings across 11 macros**, all at correct call sites like:

```csharp
GetNetworkWirelessLatencyStatsAsync(
    networkId,
    timespan == null ? startDate.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) : null,   // <- CS8604
    timespan == null ? endDate.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture)   : null,   // <- CS8604
    ...
```

## Risk

Nullability is metadata — no signature, no default value and no runtime behaviour changes, and Refit reads the value rather than the annotation. Verified rather than assumed: the test suite reports an identical **403 total / 134 failed** before and after the change (the 134 are the integration tests that need a local `appsettings.json`). `dotnet build` of the solution is clean.

Not source-breaking for callers: widening a parameter to nullable accepts everything it accepted before.

## Note for review

The two `[Body]` parameters (`NetworkAlertSettings updateNetworkAlertSettings`, `ActionBatchUpdateRequest updateOrganizationActionBatch`) are included for consistency, since their declared default is null either way. If you would rather those two stayed non-nullable and lost their default instead, say so and I will split them out.