### PR TITLE
Changelog: label the shipped 1.70.58 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## Unreleased
+## 1.70.58
 
 - Optional parameters across the Refit interfaces are now declared **nullable**: `string? t0 = null`
   rather than `string t0 = null!` (issue


### PR DESCRIPTION
The nullable optional-parameters change (#387, fixes #386) shipped as **1.70.58** — tagged, CI published it, and it is on nuget.org. Its changelog entry was still sitting under `## Unreleased`.

Same treatment e13de909 gave the 1.70.50 and 1.70.51 entries: label it with the version it shipped as.

Docs only, no code change.

Note: your local working tree has in-flight Workflows-API work that also adds to `## Unreleased`, so expect a trivial conflict on that heading when you next pull — the new section you are writing wants to sit above this one.