### PR TITLE
MCP: retry Dashboard rate limits reported in the tool payload (fixes #389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ﻿# Changelog
 
+## Unreleased
+
+- MCP: **Meraki Dashboard rate limiting is now retried transparently** (issue
+  [#389](https://github.com/panoramicdata/Meraki.Api/issues/389)). The server reports a rate limit
+  *inside an otherwise successful tool response*, answering the HTTP request with 200, so
+  `MerakiMcpBackingOffHttpMessageHandler` never saw a 429 and its retry and back-off never engaged.
+  The first rate-limited call therefore failed outright as a `MerakiMcpProtocolException`, however
+  generous `MaxAttemptCount` was - confirmed against the live hosted server, which reported
+  `Retries: 0` alongside the failure.
+  - `SemanticSearchAsync` and `ExecuteApiAsync` now retry while the server reports a rate limit,
+    honouring `MaxAttemptCount`, `BackOffDelayFactor` and `MaxBackOffDelaySeconds`, and recording
+    each wait in `MerakiMcpClientStatistics` so a slow call is still explicable.
+  - Once attempts are exhausted they throw `MerakiMcpRateLimitException`, which already carries the
+    attempt count, rather than `MerakiMcpProtocolException`. A caller that wants to come back later
+    needs to tell "busy" apart from "malformed".
+  - Rate limiting is detected from both the MCP error flag and the payload error envelope, and
+    matched on message text tolerantly, because the server supplies no machine-readable code for it.
+  - **Other payload errors are unchanged** and still fail immediately: retrying a missing required
+    parameter would spend the very budget the retry protects.
+
+  Rate limiting is an expected condition rather than an exceptional one, since an agentic
+  investigation is several capability calls in quick succession sharing the documented
+  10-requests-per-second-per-organization budget with every other consumer of the same key. Callers
+  should not have to reimplement retry logic the library already performs for HTTP 429s - and a
+  caller that hands these operations to a language model cannot retry reliably at all, because
+  whether the model retries sensibly is not a decision to delegate.
+
+
 ## 1.70.58
 
 - Optional parameters across the Refit interfaces are now declared **nullable**: `string? t0 = null`

--- a/Meraki.Api.Test/Mcp/MerakiMcpRateLimitRetryTests.cs
+++ b/Meraki.Api.Test/Mcp/MerakiMcpRateLimitRetryTests.cs
@@ -1,0 +1,250 @@
+using Meraki.Api.Mcp;
+
+namespace Meraki.Api.Test.Mcp;
+
+/// <summary>
+/// Tests that Meraki Dashboard rate limiting reported in a tool payload is retried transparently
+/// (issue #389).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server answers a rate-limited call with HTTP 200 and reports the rate limit inside the tool
+/// payload, so <see cref="MerakiMcpBackingOffHttpMessageHandler"/> never sees a 429 and its retry
+/// and back-off never engage. Before this fix the first rate-limited call failed outright, however
+/// generous <c>MaxAttemptCount</c> was - confirmed against the live hosted server, which returned
+/// <c>Retries: 0</c> alongside a rate-limit failure.
+/// </para>
+/// <para>
+/// <c>MaxBackOffDelaySeconds</c> is zero throughout, so retries are immediate and these tests stay
+/// fast while still exercising the real retry path.
+/// </para>
+/// </remarks>
+public class MerakiMcpRateLimitRetryTests
+{
+	/// <summary>The shape the hosted server actually returns when the Dashboard rate limit is hit.</summary>
+	private const string RateLimitPayload =
+		"""{"result":{"type":"error","error":"Meraki API rate limit reached.","recovery_suggestion":"Try again shortly."}}""";
+
+	private const string SuccessPayload =
+		"""{"result":{"type":"success","capability_id":"getNetworkWirelessSsids","data":[{"number":0,"name":"Corporate"}]}}""";
+
+	private static MerakiMcpClientOptions Options(int maxAttemptCount = 3)
+		=> new()
+		{
+			ApiKey = "key",
+			MaxAttemptCount = maxAttemptCount,
+			MaxBackOffDelaySeconds = 0
+		};
+
+	private static MerakiMcpClient Create(FakeMerakiMcpSession session, int maxAttemptCount = 3)
+		=> new(Options(maxAttemptCount), null, _ => Task.FromResult<IMerakiMcpSession>(session));
+
+	// ---------------------------------------------------------------- message classification
+
+	[Theory]
+	[InlineData("Meraki API rate limit reached.", true)]
+	[InlineData("MERAKI API RATE LIMIT REACHED", true)]
+	[InlineData("rate-limit exceeded", true)]
+	[InlineData("RateLimit hit", true)]
+	[InlineData("Too many requests", true)]
+	[InlineData("Received 429 from upstream", true)]
+	[InlineData("Missing required parameters", false)]
+	[InlineData("Capability not found", false)]
+	[InlineData("", false)]
+	[InlineData(null, false)]
+	public void IsRateLimitMessage_ClassifiesCorrectly(string? message, bool expected)
+		=> MerakiMcpClient.IsRateLimitMessage(message).Should().Be(expected);
+
+	// ---------------------------------------------------------------- execute_api
+
+	[Fact]
+	public async Task ExecuteApiAsync_WhenRateLimitedThenSuccessful_ReturnsTheData()
+	{
+		var callCount = 0;
+		var session = new FakeMerakiMcpSession
+		{
+			OnCallTool = (_, _, _) =>
+			{
+				callCount++;
+				return Task.FromResult(new MerakiMcpToolResponse(
+					false,
+					callCount == 1 ? RateLimitPayload : SuccessPayload,
+					null));
+			}
+		};
+
+		await using var client = Create(session);
+
+		var result = await client.ExecuteApiAsync("getNetworkWirelessSsids", parameters: null, TestContext.Current.CancellationToken);
+
+		_ = callCount.Should().Be(2);
+		_ = result.Payload.Should().Contain("Corporate");
+	}
+
+	[Fact]
+	public async Task ExecuteApiAsync_WhenRateLimitedThenSuccessful_RecordsTheRetry()
+	{
+		var callCount = 0;
+		var session = new FakeMerakiMcpSession
+		{
+			OnCallTool = (_, _, _) =>
+			{
+				callCount++;
+				return Task.FromResult(new MerakiMcpToolResponse(
+					false,
+					callCount == 1 ? RateLimitPayload : SuccessPayload,
+					null));
+			}
+		};
+
+		await using var client = Create(session);
+
+		_ = await client.ExecuteApiAsync("getNetworkWirelessSsids", parameters: null, TestContext.Current.CancellationToken);
+
+		// Observability is part of the fix: a silent retry looks identical to a slow server.
+		_ = client.Statistics.RetryCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task ExecuteApiAsync_WhenRateLimitedThroughout_ThrowsRateLimitExceptionAfterEveryAttempt()
+	{
+		var callCount = 0;
+		var session = new FakeMerakiMcpSession
+		{
+			OnCallTool = (_, _, _) =>
+			{
+				callCount++;
+				return Task.FromResult(new MerakiMcpToolResponse(false, RateLimitPayload, null));
+			}
+		};
+
+		await using var client = Create(session, maxAttemptCount: 4);
+
+		var act = async () => await client.ExecuteApiAsync("getNetworkWirelessSsids", parameters: null, TestContext.Current.CancellationToken);
+
+		// The dedicated type, not MerakiMcpProtocolException: a caller that wants to back off and
+		// come back later needs to distinguish "busy" from "malformed".
+		_ = await act.Should().ThrowAsync<MerakiMcpRateLimitException>();
+		_ = callCount.Should().Be(4);
+	}
+
+	[Fact]
+	public async Task ExecuteApiAsync_WhenPayloadErrorIsNotARateLimit_FailsImmediatelyWithoutRetrying()
+	{
+		var callCount = 0;
+		var session = new FakeMerakiMcpSession
+		{
+			OnCallTool = (_, _, _) =>
+			{
+				callCount++;
+				return Task.FromResult(new MerakiMcpToolResponse(
+					false,
+					"""{"result":{"type":"error","error":"Missing required parameters","recovery_suggestion":"Provide values for: organizationId"}}""",
+					null));
+			}
+		};
+
+		await using var client = Create(session);
+
+		var act = async () => await client.ExecuteApiAsync("getNetworkWirelessSsids", parameters: null, TestContext.Current.CancellationToken);
+
+		// Retrying a missing parameter would spend the very budget the retry logic protects.
+		_ = await act.Should().ThrowAsync<MerakiMcpProtocolException>();
+		_ = callCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task ExecuteApiAsync_WhenRateLimitArrivesViaTheMcpErrorFlag_IsAlsoRetried()
+	{
+		var callCount = 0;
+		var session = new FakeMerakiMcpSession
+		{
+			OnCallTool = (_, _, _) =>
+			{
+				callCount++;
+				return callCount == 1
+					? Task.FromResult(new MerakiMcpToolResponse(true, "Meraki API rate limit reached.", null))
+					: Task.FromResult(new MerakiMcpToolResponse(false, SuccessPayload, null));
+			}
+		};
+
+		await using var client = Create(session);
+
+		var result = await client.ExecuteApiAsync("getNetworkWirelessSsids", parameters: null, TestContext.Current.CancellationToken);
+
+		// The server has been seen using the payload envelope, but the error flag is the documented
+		// route and must behave the same way.
+		_ = callCount.Should().Be(2);
+		_ = result.Payload.Should().Contain("Corporate");
+	}
+
+	// ---------------------------------------------------------------- semantic_search
+
+	[Fact]
+	public async Task SemanticSearchAsync_WhenRateLimitedThenSuccessful_ReturnsTheCapabilities()
+	{
+		var callCount = 0;
+		var session = new FakeMerakiMcpSession
+		{
+			OnCallTool = (_, _, _) =>
+			{
+				callCount++;
+				return Task.FromResult(new MerakiMcpToolResponse(
+					false,
+					callCount == 1
+						? RateLimitPayload
+						: """{"results":[{"capability_id":"getNetworkWirelessSsids"}]}""",
+					null));
+			}
+		};
+
+		await using var client = Create(session);
+
+		var capabilities = await client.SemanticSearchAsync("wireless ssids", TestContext.Current.CancellationToken);
+
+		_ = callCount.Should().Be(2);
+		_ = capabilities.Should().ContainSingle();
+	}
+
+	[Fact]
+	public async Task SemanticSearchAsync_WhenRateLimitedThroughout_ThrowsRateLimitException()
+	{
+		var session = new FakeMerakiMcpSession
+		{
+			OnCallTool = (_, _, _) => Task.FromResult(new MerakiMcpToolResponse(false, RateLimitPayload, null))
+		};
+
+		await using var client = Create(session, maxAttemptCount: 2);
+
+		var act = async () => await client.SemanticSearchAsync("wireless ssids", TestContext.Current.CancellationToken);
+
+		_ = await act.Should().ThrowAsync<MerakiMcpRateLimitException>();
+	}
+
+	// ---------------------------------------------------------------- cancellation
+
+	[Fact]
+	public async Task ExecuteApiAsync_WhenCancelledDuringRetries_Throws()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+
+		var session = new FakeMerakiMcpSession
+		{
+			OnCallTool = (_, _, _) =>
+			{
+				cancellationTokenSource.Cancel();
+				return Task.FromResult(new MerakiMcpToolResponse(false, RateLimitPayload, null));
+			}
+		};
+
+		await using var client = Create(session, maxAttemptCount: 10);
+
+		var act = async () => await client.ExecuteApiAsync(
+			"getNetworkWirelessSsids",
+			parameters: null,
+			cancellationTokenSource.Token);
+
+		// A long retry sequence must remain interruptible; the UI offers a cancel button.
+		_ = await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+}

--- a/Meraki.Api.Test/Mcp/MerakiMcpRateLimitRetryTests.cs
+++ b/Meraki.Api.Test/Mcp/MerakiMcpRateLimitRetryTests.cs
@@ -53,7 +53,7 @@ public class MerakiMcpRateLimitRetryTests
 	[InlineData("", false)]
 	[InlineData(null, false)]
 	public void IsRateLimitMessage_ClassifiesCorrectly(string? message, bool expected)
-		=> MerakiMcpClient.IsRateLimitMessage(message).Should().Be(expected);
+		=> MerakiMcpRateLimitPolicy.IsRateLimitMessage(message).Should().Be(expected);
 
 	// ---------------------------------------------------------------- execute_api
 

--- a/Meraki.Api/Mcp/MerakiMcpClient.cs
+++ b/Meraki.Api/Mcp/MerakiMcpClient.cs
@@ -1,4 +1,4 @@
-using ModelContextProtocol.Client;
+﻿using ModelContextProtocol.Client;
 using Newtonsoft.Json.Linq;
 
 namespace Meraki.Api.Mcp;
@@ -97,6 +97,7 @@ public sealed class MerakiMcpClient : IDisposable, IAsyncDisposable
 	/// <exception cref="ArgumentException">Thrown when <paramref name="query"/> is null or whitespace.</exception>
 	/// <exception cref="ObjectDisposedException">Thrown when this client has been disposed.</exception>
 	/// <exception cref="MerakiMcpToolNotFoundException">Thrown when the server does not advertise the semantic_search tool.</exception>
+	/// <exception cref="MerakiMcpRateLimitException">Thrown when the server was still reporting a rate limit after <see cref="MerakiMcpClientOptions.MaxAttemptCount"/> attempts.</exception>
 	/// <exception cref="MerakiMcpProtocolException">Thrown when the server's response cannot be understood.</exception>
 	public async Task<IReadOnlyList<MerakiCapability>> SemanticSearchAsync(
 		string query,
@@ -109,7 +110,7 @@ public sealed class MerakiMcpClient : IDisposable, IAsyncDisposable
 			throw new ArgumentException("A natural-language query is required.", nameof(query));
 		}
 
-		var response = await CallToolAsync(
+		var response = await CallToolWithRateLimitRetryAsync(
 			SemanticSearchToolName,
 			new Dictionary<string, object?>(StringComparer.Ordinal) { ["query"] = query },
 			cancellationToken)
@@ -133,6 +134,7 @@ public sealed class MerakiMcpClient : IDisposable, IAsyncDisposable
 	/// design; use <see cref="MerakiClient"/> for mutations.
 	/// </exception>
 	/// <exception cref="MerakiMcpToolNotFoundException">Thrown when the server does not advertise the execute_api tool.</exception>
+	/// <exception cref="MerakiMcpRateLimitException">Thrown when the server was still reporting a rate limit after <see cref="MerakiMcpClientOptions.MaxAttemptCount"/> attempts.</exception>
 	/// <exception cref="MerakiMcpProtocolException">Thrown when the server reports an error or its response cannot be understood.</exception>
 	public async Task<MerakiMcpResult> ExecuteApiAsync(
 		string capabilityId,
@@ -164,7 +166,7 @@ public sealed class MerakiMcpClient : IDisposable, IAsyncDisposable
 				StringComparer.Ordinal);
 		}
 
-		var response = await CallToolAsync(ExecuteApiToolName, arguments, cancellationToken)
+		var response = await CallToolWithRateLimitRetryAsync(ExecuteApiToolName, arguments, cancellationToken)
 			.ConfigureAwait(false);
 
 		if (response.IsError)
@@ -219,6 +221,140 @@ public sealed class MerakiMcpClient : IDisposable, IAsyncDisposable
 			// The message is built from exception text only, which never contains the credential.
 			return MerakiMcpStatus.Disconnected(ex.Message);
 		}
+	}
+
+	/// <summary>
+	/// Calls a tool, transparently retrying while the server reports that the Meraki Dashboard rate
+	/// limit has been reached.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The server reports rate limiting <b>inside an otherwise successful tool response</b>, as a
+	/// payload error, and answers the HTTP request with 200. So
+	/// <see cref="MerakiMcpBackingOffHttpMessageHandler"/> - which can only see status codes - never
+	/// sees a 429 and its retry and back-off never engage. Without this, the first rate-limited call
+	/// fails outright, however generous <see cref="MerakiMcpClientOptions.MaxAttemptCount"/> is.
+	/// </para>
+	/// <para>
+	/// Rate limiting is an expected condition rather than an exceptional one: an agentic
+	/// investigation is several capability calls in quick succession, sharing the documented
+	/// 10-requests-per-second-per-organization budget with every other consumer of the same key.
+	/// Callers should not have to reimplement retry logic this library already performs for HTTP
+	/// 429s, and callers that hand these operations to a language model cannot retry reliably at
+	/// all - whether the model retries sensibly is not a decision to delegate.
+	/// </para>
+	/// <para>
+	/// Only rate-limit errors are retried. A missing required parameter is also reported as a
+	/// payload error, and retrying that would waste the very budget being protected, so it is left
+	/// to fail immediately. See issue #389.
+	/// </para>
+	/// </remarks>
+	private async Task<MerakiMcpToolResponse> CallToolWithRateLimitRetryAsync(
+		string toolName,
+		IReadOnlyDictionary<string, object?> arguments,
+		CancellationToken cancellationToken)
+	{
+		var attemptCount = 0;
+
+		while (true)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			attemptCount++;
+
+			var response = await CallToolAsync(toolName, arguments, cancellationToken)
+				.ConfigureAwait(false);
+
+			if (!TryGetRateLimitMessage(response, out var rateLimitMessage))
+			{
+				return response;
+			}
+
+			if (attemptCount >= _options.MaxAttemptCount)
+			{
+				throw new MerakiMcpRateLimitException(attemptCount);
+			}
+
+			var delay = AuthenticatedBackingOffHttpClientHandler.CalculateBackoffDelay(
+				attemptCount,
+				retryAfterSeconds: 1,
+				_options.BackOffDelayFactor,
+				_options.MaxBackOffDelaySeconds);
+
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+			_logger.LogDebug(
+				"Meraki MCP tool {ToolName} reported a rate limit on attempt {AttemptCount}/{MaxAttemptCount} ({RateLimitMessage}). Waiting {TotalSeconds:N1}s.",
+				toolName,
+				attemptCount,
+				_options.MaxAttemptCount,
+				rateLimitMessage,
+				delay.TotalSeconds);
+#pragma warning restore CA1873 // Avoid potentially expensive logging
+
+			Statistics.RecordRetry(delay);
+
+			await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+		}
+	}
+
+	/// <summary>
+	/// Determines whether a tool response reports that the Meraki Dashboard rate limit was reached.
+	/// </summary>
+	/// <remarks>
+	/// Checks both the MCP error flag and the payload error envelope, because the server has been
+	/// observed using the latter for rate limiting.
+	/// </remarks>
+	internal static bool TryGetRateLimitMessage(MerakiMcpToolResponse response, out string message)
+	{
+		message = string.Empty;
+
+		if (response.IsError)
+		{
+			if (!IsRateLimitMessage(response.Text))
+			{
+				return false;
+			}
+
+			message = response.Text!;
+			return true;
+		}
+
+		var json = response.StructuredJson ?? response.Text;
+
+		if (!TryReadPayloadError(json, out var payloadError) || !IsRateLimitMessage(payloadError))
+		{
+			return false;
+		}
+
+		message = payloadError;
+		return true;
+	}
+
+	/// <summary>
+	/// Determines whether an error message describes Meraki Dashboard rate limiting.
+	/// </summary>
+	/// <remarks>
+	/// Matched on text because the server supplies no machine-readable code for this, which is
+	/// itself worth raising with Cisco. Deliberately tolerant of wording changes during the beta:
+	/// several phrasings are accepted, and matching is case-insensitive.
+	/// </remarks>
+	internal static bool IsRateLimitMessage(string? message)
+	{
+		if (string.IsNullOrWhiteSpace(message))
+		{
+			return false;
+		}
+
+		string[] fragments = ["rate limit", "ratelimit", "rate-limit", "too many requests", "429"];
+
+		foreach (var fragment in fragments)
+		{
+			if (message!.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private async Task<MerakiMcpToolResponse> CallToolAsync(

--- a/Meraki.Api/Mcp/MerakiMcpClient.cs
+++ b/Meraki.Api/Mcp/MerakiMcpClient.cs
@@ -110,9 +110,14 @@ public sealed class MerakiMcpClient : IDisposable, IAsyncDisposable
 			throw new ArgumentException("A natural-language query is required.", nameof(query));
 		}
 
-		var response = await CallToolWithRateLimitRetryAsync(
+		var arguments = new Dictionary<string, object?>(StringComparer.Ordinal) { ["query"] = query };
+
+		var response = await MerakiMcpRateLimitPolicy.CallWithRetryAsync(
+			token => CallToolAsync(SemanticSearchToolName, arguments, token),
 			SemanticSearchToolName,
-			new Dictionary<string, object?>(StringComparer.Ordinal) { ["query"] = query },
+			_options,
+			Statistics,
+			_logger,
 			cancellationToken)
 			.ConfigureAwait(false);
 
@@ -166,7 +171,13 @@ public sealed class MerakiMcpClient : IDisposable, IAsyncDisposable
 				StringComparer.Ordinal);
 		}
 
-		var response = await CallToolWithRateLimitRetryAsync(ExecuteApiToolName, arguments, cancellationToken)
+		var response = await MerakiMcpRateLimitPolicy.CallWithRetryAsync(
+			token => CallToolAsync(ExecuteApiToolName, arguments, token),
+			ExecuteApiToolName,
+			_options,
+			Statistics,
+			_logger,
+			cancellationToken)
 			.ConfigureAwait(false);
 
 		if (response.IsError)
@@ -221,140 +232,6 @@ public sealed class MerakiMcpClient : IDisposable, IAsyncDisposable
 			// The message is built from exception text only, which never contains the credential.
 			return MerakiMcpStatus.Disconnected(ex.Message);
 		}
-	}
-
-	/// <summary>
-	/// Calls a tool, transparently retrying while the server reports that the Meraki Dashboard rate
-	/// limit has been reached.
-	/// </summary>
-	/// <remarks>
-	/// <para>
-	/// The server reports rate limiting <b>inside an otherwise successful tool response</b>, as a
-	/// payload error, and answers the HTTP request with 200. So
-	/// <see cref="MerakiMcpBackingOffHttpMessageHandler"/> - which can only see status codes - never
-	/// sees a 429 and its retry and back-off never engage. Without this, the first rate-limited call
-	/// fails outright, however generous <see cref="MerakiMcpClientOptions.MaxAttemptCount"/> is.
-	/// </para>
-	/// <para>
-	/// Rate limiting is an expected condition rather than an exceptional one: an agentic
-	/// investigation is several capability calls in quick succession, sharing the documented
-	/// 10-requests-per-second-per-organization budget with every other consumer of the same key.
-	/// Callers should not have to reimplement retry logic this library already performs for HTTP
-	/// 429s, and callers that hand these operations to a language model cannot retry reliably at
-	/// all - whether the model retries sensibly is not a decision to delegate.
-	/// </para>
-	/// <para>
-	/// Only rate-limit errors are retried. A missing required parameter is also reported as a
-	/// payload error, and retrying that would waste the very budget being protected, so it is left
-	/// to fail immediately. See issue #389.
-	/// </para>
-	/// </remarks>
-	private async Task<MerakiMcpToolResponse> CallToolWithRateLimitRetryAsync(
-		string toolName,
-		IReadOnlyDictionary<string, object?> arguments,
-		CancellationToken cancellationToken)
-	{
-		var attemptCount = 0;
-
-		while (true)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-			attemptCount++;
-
-			var response = await CallToolAsync(toolName, arguments, cancellationToken)
-				.ConfigureAwait(false);
-
-			if (!TryGetRateLimitMessage(response, out var rateLimitMessage))
-			{
-				return response;
-			}
-
-			if (attemptCount >= _options.MaxAttemptCount)
-			{
-				throw new MerakiMcpRateLimitException(attemptCount);
-			}
-
-			var delay = AuthenticatedBackingOffHttpClientHandler.CalculateBackoffDelay(
-				attemptCount,
-				retryAfterSeconds: 1,
-				_options.BackOffDelayFactor,
-				_options.MaxBackOffDelaySeconds);
-
-#pragma warning disable CA1873 // Avoid potentially expensive logging
-			_logger.LogDebug(
-				"Meraki MCP tool {ToolName} reported a rate limit on attempt {AttemptCount}/{MaxAttemptCount} ({RateLimitMessage}). Waiting {TotalSeconds:N1}s.",
-				toolName,
-				attemptCount,
-				_options.MaxAttemptCount,
-				rateLimitMessage,
-				delay.TotalSeconds);
-#pragma warning restore CA1873 // Avoid potentially expensive logging
-
-			Statistics.RecordRetry(delay);
-
-			await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-		}
-	}
-
-	/// <summary>
-	/// Determines whether a tool response reports that the Meraki Dashboard rate limit was reached.
-	/// </summary>
-	/// <remarks>
-	/// Checks both the MCP error flag and the payload error envelope, because the server has been
-	/// observed using the latter for rate limiting.
-	/// </remarks>
-	internal static bool TryGetRateLimitMessage(MerakiMcpToolResponse response, out string message)
-	{
-		message = string.Empty;
-
-		if (response.IsError)
-		{
-			if (!IsRateLimitMessage(response.Text))
-			{
-				return false;
-			}
-
-			message = response.Text!;
-			return true;
-		}
-
-		var json = response.StructuredJson ?? response.Text;
-
-		if (!TryReadPayloadError(json, out var payloadError) || !IsRateLimitMessage(payloadError))
-		{
-			return false;
-		}
-
-		message = payloadError;
-		return true;
-	}
-
-	/// <summary>
-	/// Determines whether an error message describes Meraki Dashboard rate limiting.
-	/// </summary>
-	/// <remarks>
-	/// Matched on text because the server supplies no machine-readable code for this, which is
-	/// itself worth raising with Cisco. Deliberately tolerant of wording changes during the beta:
-	/// several phrasings are accepted, and matching is case-insensitive.
-	/// </remarks>
-	internal static bool IsRateLimitMessage(string? message)
-	{
-		if (string.IsNullOrWhiteSpace(message))
-		{
-			return false;
-		}
-
-		string[] fragments = ["rate limit", "ratelimit", "rate-limit", "too many requests", "429"];
-
-		foreach (var fragment in fragments)
-		{
-			if (message!.Contains(fragment, StringComparison.OrdinalIgnoreCase))
-			{
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private async Task<MerakiMcpToolResponse> CallToolAsync(

--- a/Meraki.Api/Mcp/MerakiMcpRateLimitPolicy.cs
+++ b/Meraki.Api/Mcp/MerakiMcpRateLimitPolicy.cs
@@ -1,0 +1,164 @@
+namespace Meraki.Api.Mcp;
+
+/// <summary>
+/// Recognises Meraki Dashboard rate limiting in an MCP tool response, and retries around it
+/// (issue #389).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server reports a rate limit <b>inside an otherwise successful tool response</b>, answering
+/// the HTTP request with 200. So <see cref="MerakiMcpBackingOffHttpMessageHandler"/> - which can
+/// only see status codes - never sees a 429, and its retry and back-off never engage. Without this
+/// policy the first rate-limited call fails outright, however generous
+/// <see cref="MerakiMcpClientOptions.MaxAttemptCount"/> is.
+/// </para>
+/// <para>
+/// Rate limiting is an expected condition rather than an exceptional one: an agentic investigation
+/// is several capability calls in quick succession, sharing the documented
+/// 10-requests-per-second-per-organization budget with every other consumer of the same key.
+/// Callers should not have to reimplement retry logic this library already performs for HTTP 429s,
+/// and callers that hand these operations to a language model cannot retry reliably at all -
+/// whether the model retries sensibly is not a decision to delegate.
+/// </para>
+/// <para>
+/// This lives apart from <see cref="MerakiMcpClient"/> because it is a self-contained policy with
+/// no dependency on client state, and because the client file was already large enough that adding
+/// it there made the file the thing that was doing too much.
+/// </para>
+/// </remarks>
+internal static class MerakiMcpRateLimitPolicy
+{
+	/// <summary>
+	/// Message fragments that indicate Dashboard rate limiting.
+	/// </summary>
+	/// <remarks>
+	/// Matched on text because the server supplies no machine-readable code for this, which is
+	/// itself worth raising with Cisco. Deliberately tolerant of wording changes during the beta.
+	/// </remarks>
+	private static readonly string[] _rateLimitMessageFragments =
+	[
+		"rate limit",
+		"ratelimit",
+		"rate-limit",
+		"too many requests",
+		"429",
+	];
+
+	/// <summary>
+	/// Invokes a tool call, retrying while the server reports that the rate limit was reached.
+	/// </summary>
+	/// <param name="callTool">Performs one tool call.</param>
+	/// <param name="toolName">The tool being called, for logging.</param>
+	/// <param name="options">The client options governing attempts and back-off.</param>
+	/// <param name="statistics">Statistics to record each wait against.</param>
+	/// <param name="logger">A logger.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>The first response that does not report a rate limit.</returns>
+	/// <exception cref="MerakiMcpRateLimitException">
+	/// Thrown when the server was still reporting a rate limit after
+	/// <see cref="MerakiMcpClientOptions.MaxAttemptCount"/> attempts.
+	/// </exception>
+	internal static async Task<MerakiMcpToolResponse> CallWithRetryAsync(
+		Func<CancellationToken, Task<MerakiMcpToolResponse>> callTool,
+		string toolName,
+		MerakiMcpClientOptions options,
+		MerakiMcpClientStatistics statistics,
+		ILogger logger,
+		CancellationToken cancellationToken)
+	{
+		var attemptCount = 0;
+
+		while (true)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			attemptCount++;
+
+			var response = await callTool(cancellationToken).ConfigureAwait(false);
+
+			if (!TryGetRateLimitMessage(response, out var rateLimitMessage))
+			{
+				return response;
+			}
+
+			if (attemptCount >= options.MaxAttemptCount)
+			{
+				throw new MerakiMcpRateLimitException(attemptCount);
+			}
+
+			var delay = AuthenticatedBackingOffHttpClientHandler.CalculateBackoffDelay(
+				attemptCount,
+				retryAfterSeconds: 1,
+				options.BackOffDelayFactor,
+				options.MaxBackOffDelaySeconds);
+
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+			logger.LogDebug(
+				"Meraki MCP tool {ToolName} reported a rate limit on attempt {AttemptCount}/{MaxAttemptCount} ({RateLimitMessage}). Waiting {TotalSeconds:N1}s.",
+				toolName,
+				attemptCount,
+				options.MaxAttemptCount,
+				rateLimitMessage,
+				delay.TotalSeconds);
+#pragma warning restore CA1873 // Avoid potentially expensive logging
+
+			statistics.RecordRetry(delay);
+
+			await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+		}
+	}
+
+	/// <summary>
+	/// Determines whether a tool response reports that the Meraki Dashboard rate limit was reached.
+	/// </summary>
+	/// <remarks>
+	/// Checks both the MCP error flag and the payload error envelope, because the server has been
+	/// observed using the latter for rate limiting.
+	/// </remarks>
+	internal static bool TryGetRateLimitMessage(MerakiMcpToolResponse response, out string message)
+	{
+		message = string.Empty;
+
+		if (response.IsError)
+		{
+			if (!IsRateLimitMessage(response.Text))
+			{
+				return false;
+			}
+
+			message = response.Text!;
+			return true;
+		}
+
+		var json = response.StructuredJson ?? response.Text;
+
+		if (!MerakiMcpClient.TryReadPayloadError(json, out var payloadError)
+			|| !IsRateLimitMessage(payloadError))
+		{
+			return false;
+		}
+
+		message = payloadError;
+		return true;
+	}
+
+	/// <summary>
+	/// Determines whether an error message describes Meraki Dashboard rate limiting.
+	/// </summary>
+	internal static bool IsRateLimitMessage(string? message)
+	{
+		if (string.IsNullOrWhiteSpace(message))
+		{
+			return false;
+		}
+
+		foreach (var fragment in _rateLimitMessageFragments)
+		{
+			if (message!.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
Fixes #389.

The MCP server reports Dashboard rate limiting **inside an otherwise successful tool response**, answering the HTTP request with 200. `MerakiMcpBackingOffHttpMessageHandler` only sees status codes, so it never saw a 429 and its retry and back-off never engaged — the first rate-limited call failed outright as `MerakiMcpProtocolException`, however generous `MaxAttemptCount` was.

Confirmed against the live hosted server:

```
EXCEPTION TYPE: MerakiMcpProtocolException
MESSAGE: ... Meraki API rate limit reached.. Try again shortly.
Tool calls: 1, Retries: 0, Back-off: 0ms. Status codes: 200: 3, 202: 1, 400: 1, 405: 1
```

## What changed

- `SemanticSearchAsync` and `ExecuteApiAsync` retry while the server reports a rate limit, honouring `MaxAttemptCount`, `BackOffDelayFactor` and `MaxBackOffDelaySeconds`, recording each wait in `MerakiMcpClientStatistics`.
- Exhausted attempts throw `MerakiMcpRateLimitException` (which already carries the attempt count) rather than `MerakiMcpProtocolException`.
- Detection covers both the MCP error flag and the payload envelope, matched tolerantly on message text since the server supplies no machine-readable code.
- **Other payload errors are unchanged** and still fail immediately — retrying a missing required parameter would spend the very budget being protected.

## Testing

18 new tests in `MerakiMcpRateLimitRetryTests`, covering retry-then-succeed, exhaustion, the error-flag route, non-rate-limit payload errors not being retried, statistics, and cancellation mid-retry. All 179 MCP tests green.

## Note for Cisco

Worth raising as design-partner feedback: reporting a rate limit in a success payload rather than via MCP error semantics or an HTTP 429 with `Retry-After` forces every client to match on message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)