### PR TITLE
fix: redact sensitive HTTP headers, and restore the analyzer target framework

### DIFF
--- a/Meraki.Api.Test/Extensions/HttpExtensionsTests.cs
+++ b/Meraki.Api.Test/Extensions/HttpExtensionsTests.cs
@@ -1,0 +1,248 @@
+using Meraki.Api.Extensions;
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Meraki.Api.Test.Extensions;
+
+/// <summary>
+/// Tests for header redaction in diagnostic output.
+///
+/// <para>
+/// <c>AuthenticatedBackingOffHttpClientHandler</c> applies a credential to every request and then
+/// passes the whole <see cref="HttpRequestMessage"/> to the logger. Its <c>ToString()</c> renders
+/// every header, so without redaction a usable credential is written wherever those messages end
+/// up.
+/// </para>
+///
+/// <para>
+/// Which credential depends on configuration. With an access token, or when the Workflows API is in
+/// use, it is an Authorization bearer header. Otherwise it is the API key in
+/// <c>X-Cisco-Meraki-API-Key</c>, which is the more sensitive of the two because a Meraki API key
+/// does not expire.
+/// </para>
+///
+/// <para>
+/// These are pure unit tests. They construct messages directly and require no credentials, no
+/// configuration and no live organisation.
+/// </para>
+/// </summary>
+public class HttpExtensionsTests
+{
+	private const string FakeApiKey = "0123456789abcdef0123456789abcdef01234567";
+	private const string FakeToken = "fake-access-token-0123456789abcdef";
+
+	/// <summary>
+	/// The headline case: the API key must not survive into the message.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_MerakiApiKeyHeader_DoesNotLeakTheKey()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/api/v1/organizations");
+		request.Headers.Add("X-Cisco-Meraki-API-Key", FakeApiKey);
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().NotContain(FakeApiKey);
+		rendered.Should().Contain($"X-Cisco-Meraki-API-Key: <redacted, length {FakeApiKey.Length}>");
+	}
+
+	/// <summary>
+	/// The other credential path, used with an access token or the Workflows API.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_BearerToken_KeepsTheSchemeAndRedactsTheCredential()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/api/v1/organizations");
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", FakeToken);
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().NotContain(FakeToken);
+		rendered.Should().Contain($"Authorization: Bearer <redacted, length {FakeToken.Length}>");
+	}
+
+	/// <summary>
+	/// Proves the defect being fixed: the framework rendering leaks, the replacement does not.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_UnlikeToString_DoesNotContainTheKey()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/api/v1/organizations");
+		request.Headers.Add("X-Cisco-Meraki-API-Key", FakeApiKey);
+
+		request.ToString().Should().Contain(FakeApiKey, "the framework rendering is what leaked");
+		request.ToRedactedString().Should().NotContain(FakeApiKey);
+	}
+
+	/// <summary>
+	/// The diagnostically useful parts of the message must survive intact.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_KeepsMethodUriAndOtherHeaders()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Put, "https://api.meraki.com/api/v1/networks/N_123/devices");
+		request.Headers.Add("X-Cisco-Meraki-API-Key", FakeApiKey);
+		request.Headers.TryAddWithoutValidation("User-Agent", "Meraki.Api");
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().Contain("Method: PUT");
+		rendered.Should().Contain("https://api.meraki.com/api/v1/networks/N_123/devices");
+		rendered.Should().Contain("User-Agent: Meraki.Api");
+		rendered.Should().NotContain(FakeApiKey);
+	}
+
+	/// <summary>
+	/// Content headers are rendered too, so they must be redacted on the same terms.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_RedactsContentHeaders()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.meraki.com/api/v1/organizations")
+		{
+			Content = new StringContent("{}")
+		};
+		request.Content!.Headers.TryAddWithoutValidation("X-Api-Key", "s3cr3t-content-header");
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().NotContain("s3cr3t-content-header");
+		rendered.Should().Contain("<redacted");
+		rendered.Should().Contain("Content-Type: text/plain; charset=utf-8");
+	}
+
+	/// <summary>
+	/// A header added without validation keeps whatever casing the caller used.
+	/// </summary>
+	/// <param name="headerName">The header name casing under test.</param>
+	[Theory]
+	[InlineData("x-cisco-meraki-api-key")]
+	[InlineData("X-CISCO-MERAKI-API-KEY")]
+	[InlineData("authorization")]
+	[InlineData("AUTHORIZATION")]
+	public void ToRedactedString_CredentialHeaders_AreRedactedWhateverTheCasing(string headerName)
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/");
+		request.Headers.TryAddWithoutValidation(headerName, FakeApiKey);
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().NotContain(FakeApiKey);
+		rendered.Should().Contain("<redacted");
+	}
+
+	/// <summary>
+	/// The other standard credential-bearing header names are redacted too.
+	/// </summary>
+	/// <param name="headerName">The credential-bearing header name under test.</param>
+	[Theory]
+	[InlineData("Proxy-Authorization")]
+	[InlineData("Cookie")]
+	[InlineData("X-API-Key")]
+	[InlineData("Api-Key")]
+	[InlineData("X-Api-Token")]
+	[InlineData("X-Auth-Token")]
+	public void ToRedactedString_OtherCredentialHeaders_AreRedacted(string headerName)
+	{
+		const string secret = "s3cr3t-value-that-must-not-be-logged";
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/");
+		request.Headers.TryAddWithoutValidation(headerName, secret);
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().NotContain(secret);
+		rendered.Should().Contain("<redacted");
+	}
+
+	/// <summary>
+	/// A vendor may prefix the standard header name rather than using it directly.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_VendorPrefixedAuthorizationHeader_IsRedacted()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/");
+		request.Headers.TryAddWithoutValidation("X-Vendor-Authorization", $"Bearer {FakeToken}");
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().NotContain(FakeToken);
+		rendered.Should().Contain($"X-Vendor-Authorization: Bearer <redacted, length {FakeToken.Length}>");
+	}
+
+	/// <summary>
+	/// The API key has no scheme prefix, so all of it goes rather than a leading fragment surviving.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_KeyWithoutAScheme_IsRedactedEntirely()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/");
+		request.Headers.Add("X-Cisco-Meraki-API-Key", "abcdef123456");
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().Contain("X-Cisco-Meraki-API-Key: <redacted, length 12>");
+	}
+
+	/// <summary>
+	/// A cookie value also contains a space, so treating the text before the first space as a scheme
+	/// would preserve the very value being redacted. Only Authorization style headers keep a scheme.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_CookieValueContainingASpace_IsRedactedWhole()
+	{
+		const string cookie = "session=abc123def456; HttpOnly";
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/");
+		request.Headers.TryAddWithoutValidation("Cookie", cookie);
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().Contain($"Cookie: <redacted, length {cookie.Length}>");
+		rendered.Should().NotContain("session=abc");
+	}
+
+	/// <summary>
+	/// Response rendering goes through the same redaction, so Set-Cookie is covered.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_ResponseSetCookie_IsRedacted()
+	{
+		using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+		response.Headers.TryAddWithoutValidation("Set-Cookie", "session=abc123def456; HttpOnly");
+
+		var rendered = response.ToRedactedString();
+
+		rendered.Should().NotContain("abc123def456");
+		rendered.Should().Contain("<redacted");
+	}
+
+	/// <summary>
+	/// The status and Retry-After header drive the back-off, so a rate-limit investigation must not
+	/// lose them.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_ResponseKeepsStatusAndRetryAfter()
+	{
+		using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+		response.Headers.TryAddWithoutValidation("Retry-After", "2");
+
+		var rendered = response.ToRedactedString();
+
+		rendered.Should().Contain("StatusCode: 429");
+		rendered.Should().Contain("Retry-After: 2");
+	}
+
+	/// <summary>
+	/// A request carrying no credential is rendered with nothing removed.
+	/// </summary>
+	[Fact]
+	public void ToRedactedString_NoCredentialHeaders_RedactsNothing()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/");
+		request.Headers.TryAddWithoutValidation("User-Agent", "Meraki.Api");
+
+		var rendered = request.ToRedactedString();
+
+		rendered.Should().Contain("User-Agent: Meraki.Api");
+		rendered.Should().NotContain("<redacted");
+	}
+}

--- a/Meraki.Api/AuthenticatedBackingOffHttpClientHandler.cs
+++ b/Meraki.Api/AuthenticatedBackingOffHttpClientHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace Meraki.Api;
+﻿using Meraki.Api.Extensions;
+
+namespace Meraki.Api;
 
 internal sealed class AuthenticatedBackingOffHttpClientHandler : DelegatingHandler
 {
@@ -417,7 +419,7 @@ internal sealed class AuthenticatedBackingOffHttpClientHandler : DelegatingHandl
 			return;
 		}
 
-		_logger.Log(_levelToLogAt, "{LogPrefix}Request\r\n{Request}", logPrefix, request);
+		_logger.Log(_levelToLogAt, "{LogPrefix}Request\r\n{Request}", logPrefix, request.ToRedactedString());
 		if (request.Content != null)
 		{
 			var requestContent = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -433,7 +435,7 @@ internal sealed class AuthenticatedBackingOffHttpClientHandler : DelegatingHandl
 			return;
 		}
 
-		_logger.Log(_levelToLogAt, "{LogPrefix}Response\r\n{HttpResponseMessage}", logPrefix, httpResponseMessage);
+		_logger.Log(_levelToLogAt, "{LogPrefix}Response\r\n{HttpResponseMessage}", logPrefix, httpResponseMessage.ToRedactedString());
 		if (httpResponseMessage.Content != null)
 		{
 			var responseContent = await httpResponseMessage.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);

--- a/Meraki.Api/Extensions/HttpExtensions.cs
+++ b/Meraki.Api/Extensions/HttpExtensions.cs
@@ -1,0 +1,161 @@
+using System.Text;
+
+namespace Meraki.Api.Extensions;
+
+/// <summary>
+/// Rendering of HTTP requests and responses for diagnostic output, with credential-bearing header
+/// values redacted.
+/// </summary>
+/// <remarks>
+/// The handler logs the whole <see cref="HttpRequestMessage"/> as a log argument. Its
+/// <c>ToString()</c> renders every header, so the credential this client sets on each request was
+/// written verbatim into the log. These helpers produce the same information with the credential
+/// removed.
+/// </remarks>
+internal static class HttpExtensions
+{
+	/// <summary>
+	/// Header names whose values carry a credential and must never be rendered into a log message or
+	/// an exception message.
+	/// </summary>
+	/// <remarks>
+	/// This client sends one of two credentials depending on configuration: an Authorization bearer
+	/// token, or the API key in X-Cisco-Meraki-API-Key. The latter is the reason a list copied from a
+	/// sibling package would not have fixed this one, and it is the more sensitive of the two because
+	/// a Meraki API key does not expire.
+	/// </remarks>
+	private static readonly HashSet<string> SensitiveHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"X-Cisco-Meraki-API-Key",
+		"Authorization",
+		"Proxy-Authorization",
+		"Cookie",
+		"Set-Cookie",
+		"X-API-Key",
+		"Api-Key",
+		"X-Api-Token",
+		"X-Auth-Token",
+	};
+
+	/// <summary>
+	/// The subset of sensitive headers whose value is of the form "&lt;scheme&gt; &lt;credential&gt;",
+	/// where the scheme is safe to keep and useful to see.
+	/// </summary>
+	private static readonly HashSet<string> SchemePrefixedHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"Authorization",
+		"Proxy-Authorization",
+	};
+
+	/// <summary>
+	/// Whether a header name denotes a credential-bearing header.
+	/// </summary>
+	/// <remarks>
+	/// The suffix test catches vendor-prefixed variants of the standard header, which an exact-match
+	/// list alone would render verbatim.
+	/// </remarks>
+	private static bool IsSensitive(string name)
+		=> SensitiveHeaderNames.Contains(name)
+		|| name.EndsWith("Authorization", StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Whether a header's grammar is "&lt;scheme&gt; &lt;credential&gt;", so its scheme can be kept.
+	/// </summary>
+	private static bool IsSchemePrefixed(string name)
+		=> SchemePrefixedHeaderNames.Contains(name)
+		|| name.EndsWith("Authorization", StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Joins a header's values, replacing the credential with a redaction marker when the header is a
+	/// sensitive one.
+	/// </summary>
+	/// <remarks>
+	/// The authentication scheme and the credential length are preserved. That is enough to tell an
+	/// engineer that a credential was sent and roughly what shape it had, which is all diagnosis needs,
+	/// without writing the credential itself somewhere it will be retained and widely readable.
+	/// </remarks>
+	internal static string RedactIfSensitive(string name, IEnumerable<string> values)
+	{
+		var value = string.Join(", ", values);
+
+		if (value.Length == 0 || !IsSensitive(name))
+		{
+			return value;
+		}
+
+		// Only headers whose grammar is "<scheme> <credential>" keep their scheme, so that which
+		// authentication mechanism was used remains visible. Applying this to any header containing a
+		// space would be unsafe: a cookie such as "session=abc123; HttpOnly" also contains one, and
+		// treating the text before it as a scheme would preserve the very value being redacted.
+		if (IsSchemePrefixed(name))
+		{
+			var schemeLength = value.IndexOf(' ', StringComparison.Ordinal);
+
+			if (schemeLength > 0)
+			{
+				return $"{value[..schemeLength]} <redacted, length {value.Length - schemeLength - 1}>";
+			}
+		}
+
+		return $"<redacted, length {value.Length}>";
+	}
+
+	/// <summary>
+	/// Renders a request for diagnostic output, in the shape of <c>HttpRequestMessage.ToString()</c>
+	/// but with credential-bearing header values redacted.
+	/// </summary>
+	internal static string ToRedactedString(this HttpRequestMessage request)
+	{
+		var stringBuilder = new StringBuilder()
+			.Append("Method: ").Append(request.Method)
+			.Append(", RequestUri: '").Append(request.RequestUri?.ToString() ?? "<null>")
+			.Append("', Version: ").Append(request.Version)
+			.Append(", Content: ").Append(request.Content?.GetType().FullName ?? "<null>")
+			.AppendLine(", Headers:");
+
+		AppendHeaders(stringBuilder, request.Headers, request.Content?.Headers);
+
+		return stringBuilder.ToString();
+	}
+
+	/// <summary>
+	/// Renders a response for diagnostic output, in the shape of <c>HttpResponseMessage.ToString()</c>
+	/// but with credential-bearing header values redacted.
+	/// </summary>
+	internal static string ToRedactedString(this HttpResponseMessage response)
+	{
+		var stringBuilder = new StringBuilder()
+			.Append("StatusCode: ").Append((int)response.StatusCode)
+			.Append(", ReasonPhrase: '").Append(response.ReasonPhrase ?? "<null>")
+			.Append("', Version: ").Append(response.Version)
+			.Append(", Content: ").Append(response.Content?.GetType().FullName ?? "<null>")
+			.AppendLine(", Headers:");
+
+		AppendHeaders(stringBuilder, response.Headers, response.Content?.Headers);
+
+		return stringBuilder.ToString();
+	}
+
+	/// <summary>
+	/// Appends the message headers and, where present, the content headers, each redacted.
+	/// </summary>
+	private static void AppendHeaders(StringBuilder stringBuilder, HttpHeaders headers, HttpHeaders? contentHeaders)
+	{
+		_ = stringBuilder.AppendLine("{");
+
+		foreach (var header in headers)
+		{
+			_ = stringBuilder.Append("  ").Append(header.Key).Append(": ").AppendLine(RedactIfSensitive(header.Key, header.Value));
+		}
+
+		if (contentHeaders is not null)
+		{
+			foreach (var header in contentHeaders)
+			{
+				_ = stringBuilder.Append("  ").Append(header.Key).Append(": ").AppendLine(RedactIfSensitive(header.Key, header.Value));
+			}
+		}
+
+		_ = stringBuilder.Append('}');
+	}
+}

--- a/Meraki.Api/Meraki.Api.csproj
+++ b/Meraki.Api/Meraki.Api.csproj
@@ -33,7 +33,29 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Changelog can be found at https://github.com/panoramicdata/Meraki.Api/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>
+      Security fix: sensitive HTTP headers are now redacted in diagnostic output.
+
+      Previously AuthenticatedBackingOffHttpClientHandler passed the whole HttpRequestMessage to
+      the logger, and its ToString() renders every header. Whichever credential the client was
+      configured to send was therefore written verbatim: an Authorization bearer token, or the API
+      key in X-Cisco-Meraki-API-Key. The response side did the same, exposing Set-Cookie.
+
+      A Meraki API key does not expire, so an exposed key stays usable until it is regenerated.
+
+      X-Cisco-Meraki-API-Key, Authorization, Proxy-Authorization, Cookie, Set-Cookie and common API
+      key headers are now redacted, case-insensitively, on request and response. The scheme and
+      credential length are retained, so failures remain diagnosable.
+
+      Breaking change to message text: the Request and Response log messages are now rendered by
+      this library rather than by HttpRequestMessage.ToString(). The shape is the same but code
+      parsing those messages should be checked.
+
+      Consumers should upgrade, review existing Trace logs for previously captured credentials, and
+      regenerate any API key that appears in them.
+
+      Changelog can be found at https://github.com/panoramicdata/Meraki.Api/blob/main/CHANGELOG.md
+    </PackageReleaseNotes>
     <PackageId>Meraki.Api</PackageId>
     <NeutralResourcesLanguage>en</NeutralResourcesLanguage>
   </PropertyGroup>

--- a/RefitClassSourceGenerator/RefitClassSourceGenerator.csproj
+++ b/RefitClassSourceGenerator/RefitClassSourceGenerator.csproj
@@ -4,7 +4,7 @@
     <!-- MUST stay netstandard2.0. This assembly is a Roslyn analyzer and source generator, which
          the compiler loads in-process; RS1041 fails the build on any other target framework.
          Do not "modernise" this to a net*.0 target. -->
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>


### PR DESCRIPTION
## ⚠️ Nothing in this repository builds on `main`

Before the security fix, this PR restores one line. **`RefitClassSourceGenerator` fails with twelve analyser errors on `main`**, and because `Meraki.Api` references it with `OutputItemType="Analyzer"` the generator must build before the library can — so the whole solution is blocked.

The cause is the analyzer's target framework. A Roslyn analyzer and source generator is loaded in-process by the compiler and must target `netstandard2.0`; `bfaf03fbf` changed it to `net10.0`, which trips `RS1041` three times and brings a different analyser set with it, producing the other nine errors.

**This is the second time, and the file already said not to.** Earlier the same day, `98b795c70` restored `netstandard2.0` and added this comment:

```xml
<!-- MUST stay netstandard2.0. This assembly is a Roslyn analyzer and source generator, which
     the compiler loads in-process; RS1041 fails the build on any other target framework.
     Do not "modernise" this to a net*.0 target. -->
<TargetFramework>netstandard2.0</TargetFramework>
```

`bfaf03fbf` — "NuGet governance remediation" — changed the line *directly underneath that comment* and left the comment in place. The file has since documented the opposite of what it does.

`dcf1e0e6` restores it. That single line fixes all twelve errors: the generator builds 0 errors / 0 warnings, and so does the solution.

I checked for wider exposure: `RefitClassSourceGenerator` is the only project across the whole `D:\Source` estate that anything references as an in-process analyzer, so no sibling repository carries the same defect.

## The security fix

`AuthenticatedBackingOffHttpClientHandler` applies a credential to every request and then passes the **whole `HttpRequestMessage`** to the logger (`:420`, and `:436` for the response). `ToString()` renders the complete header collection, so the credential was written verbatim.

Which credential depends on configuration:

| Condition | Header |
|---|---|
| Access token set, or Workflows API in use (`:513`) | `Authorization: Bearer …` |
| Otherwise (`:517`) | `X-Cisco-Meraki-API-Key: …` |

That second name is why a list copied from a sibling package would not have fixed this, and it is the more serious of the two — **a Meraki API key does not expire**, so an exposed key stays usable until somebody regenerates it. Fifth package in the sweep where remediation means *rotate*, not just purge.

**There is no header-joining loop here to notice.** The leak is a message object passed as a log argument — which is exactly why the audit recorded on MS-25618 cleared this package.

Both sites now render through `ToRedactedString()`. `X-Cisco-Meraki-API-Key` has no scheme so all of it goes; `Authorization` keeps its scheme. Tests cover both, plus the cookie case where treating text-before-space as a scheme would leak the value.

## Also checked, and correctly clean

`MerakiMcpBackingOffHttpMessageHandler` sets an `Authorization` bearer header too, but logs only the method, URI and status code — never the message object or its headers. **No change needed there**, recorded so it isn't re-audited.

## Verification

21 unit tests, no credentials and no live organisation. All pass. Placed in `Meraki.Api.Test/Extensions` to mirror where the helper lives.

Only this class was run — the wider suite exercises live infrastructure and was deliberately not touched.

```
Total: 21, Errors: 0, Failed: 0, Skipped: 0
```

`dotnet build Meraki.Api.slnx -c Release` — **0 errors** (was 12 on `main`).

## Note for consumers

The `Request` and `Response` log messages are now rendered by this library rather than by `HttpRequestMessage.ToString()`. The shape is the same, but anything parsing those messages should be checked.

Refs MS-25680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
