### PR TITLE
Add missing serial number prefix: Q5AP (CW9166I)

### DIFF
--- a/Meraki.Api.Test/SerialNumberInfo/Tests.cs
+++ b/Meraki.Api.Test/SerialNumberInfo/Tests.cs
@@ -5,6 +5,7 @@ public class Tests
 	[Theory]
 	[InlineData("Q2AT-1234-1234", "MC74", ProductType.Phone, false)]
 	[InlineData("Q5AC-1234-1234", "CW9164I", ProductType.Wireless, false)]
+	[InlineData("Q5AP-1234-1234", "CW9166I", ProductType.Wireless, false)]
 	public void GetFromSerialNumber(string serialNumber, string productName, ProductType productType, bool isVirtual)
 	{
 		var result = MerakiClient.GetInfoFromSerialNumber(serialNumber);

--- a/Meraki.Api/Data/SerialNumberModels.json
+++ b/Meraki.Api/Data/SerialNumberModels.json
@@ -330,5 +330,7 @@
 	"Q5FB": "C9200L-24P-4X",
 	// Added 2026-09-03 from DataMagic prod logs (serials seen in Meraki inventory but previously unmapped)
 	"Q5FA": "C9200L-24T-4X",
-	"Q5FL": "C9200L-24P-4G"
+	"Q5FL": "C9200L-24P-4G",
+	// Added 2026-09-07 (serial seen in Meraki inventory but previously unmapped)
+	"Q5AP": "CW9166I"
 }


### PR DESCRIPTION
Adds the missing `Q5AP` serial prefix to `SerialNumberModels.json`, mapped to `CW9166I` — same model as the existing `Q5AE`/`Q5AM`/`Q5AR` entries. `GetInfoFromSerialNumber` previously returned a null `ProductType` for this prefix. Includes a corresponding test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)