### PR TITLE
fix: widen appliance uplink usage Sent/Received to long (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- `OrganizationApplianceUplinksUsageByNetworkItemByUplinkItem.Sent` and `.Received` are now `long`
+  (issue [#360](https://github.com/panoramicdata/Meraki.Api/issues/360)). They hold cumulative byte
+  counts for a window of up to 31 days, which routinely exceed `Int32.MaxValue` (about 2.1 GB) on a
+  busy uplink; the response then failed to deserialize and the whole call threw. Binary-compatible for
+  callers using `var`; a source break only for code that declared the property type as `int` explicitly.
+
 - **BREAKING: the `netstandard2.0` target has been dropped. This package now targets `net10.0` only.**
   Consumers who need `netstandard2.0` should stay on 1.70.79.
   - Note the version does not jump to 2.0: this package's version tracks the Meraki Dashboard API

--- a/Meraki.Api.Test/Data/OrganizationApplianceUplinksUsageByNetworkItemByUplinkItemTests.cs
+++ b/Meraki.Api.Test/Data/OrganizationApplianceUplinksUsageByNetworkItemByUplinkItemTests.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for
+/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/360">issue 360</see>: the
+/// cumulative byte counters on appliance uplink usage exceed Int32.MaxValue on busy networks.
+/// </summary>
+public class OrganizationApplianceUplinksUsageByNetworkItemByUplinkItemTests
+{
+	// 5 TB sent, 3 TB received: a plausible 31-day figure for a busy uplink, far above Int32.MaxValue.
+	private const string Json = """
+		{
+			"serial": "Q2QN-9J8L-SLPD",
+			"interface": "wan1",
+			"sent": 5000000000000,
+			"received": 3000000000000
+		}
+		""";
+
+	[Fact]
+	public void Deserialize_ByteCountsAboveInt32MaxValue_Succeeds()
+	{
+		var item = JsonConvert.DeserializeObject<OrganizationApplianceUplinksUsageByNetworkItemByUplinkItem>(Json);
+
+		_ = item.Should().NotBeNull();
+		_ = item!.Sent.Should().Be(5_000_000_000_000L);
+		_ = item.Received.Should().Be(3_000_000_000_000L);
+	}
+}

--- a/Meraki.Api/Data/OrganizationApplianceUplinksUsageByNetworkItemByUplinkItem.cs
+++ b/Meraki.Api/Data/OrganizationApplianceUplinksUsageByNetworkItemByUplinkItem.cs
@@ -11,14 +11,14 @@ public class OrganizationApplianceUplinksUsageByNetworkItemByUplinkItem
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "received")]
-	public int Received { get; set; }
+	public long Received { get; set; }
 
 	/// <summary>
 	/// Bytes sent
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "sent")]
-	public int Sent { get; set; }
+	public long Sent { get; set; }
 
 	/// <summary>
 	/// Uplink name


### PR DESCRIPTION
Closes #360

## What

`OrganizationApplianceUplinksUsageByNetworkItemByUplinkItem.Sent` and `.Received` change from `int` to `long`.

## Why

`GET /organizations/{organizationId}/appliance/uplinks/usageByNetwork` returns cumulative byte counts for a window of up to 31 days. On a busy uplink these exceed `Int32.MaxValue` (~2.1 GB), Newtonsoft throws `JsonReaderException`, Refit wraps it in `ApiException`, and the whole call fails with no partial result.

## Compatibility

Binary-compatible for callers using `var`. Source break only for code that declared the property type as `int` explicitly. None of the known internal consumers (DNA.Assure, DNA.WiserWatts, Cae.Portal) reference this type.

## Test

`OrganizationApplianceUplinksUsageByNetworkItemByUplinkItemTests` deserializes 5 TB / 3 TB values. Written first; it failed to compile against the `int` properties, passes after the change.

## Follow-up (not in this PR)

The same narrow-`int` pattern exists on at least seven other traffic DTOs (`BandwidthUsageHistory`, `NetworkTraffic`, `ClientTrafficHistory`, `ApplicationUsageSummary`, `ApplicationCategoryUsageSummary`, `DeviceModelUsageSummaryUsage`, `NetworkStatusSummaryClientsUsage`). Worth a separate audit PR.