### PR TITLE
docs: explain the retry options and why the defaults are persistent (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Documented how the retry options interact and why the defaults are what they are
+  (issue [#378](https://github.com/panoramicdata/Meraki.Api/issues/378)). The XML comment on
+  `MaxBackOffDelaySeconds` claimed the back-off "doubles on each attempt", which describes
+  `BackOffDelayFactor = 2.0` rather than the shipped default of 1.0, and `MaxAttemptCount` had no
+  description at all. Both now state what actually happens: at the defaults the delay is flat (the
+  server's `Retry-After`, or one second), and `HttpClientTimeoutSeconds` rather than `MaxAttemptCount`
+  is what ends a call the API keeps throttling. The README gains a "Retries, back-off and rate
+  limiting" section with a fail-fast example. **No default or behaviour changed.** The persistent
+  defaults are deliberate: Meraki's limit is shared per organization with aggressive consumers such as
+  Splunk, and the most reliable way to get a call through is to keep re-asking.
+
 - `OrganizationApplianceUplinksUsageByNetworkItemByUplinkItem.Sent` and `.Received` are now `long`
   (issue [#360](https://github.com/panoramicdata/Meraki.Api/issues/360)). They hold cumulative byte
   counts for a window of up to 31 days, which routinely exceed `Int32.MaxValue` (about 2.1 GB) on a

--- a/Meraki.Api/MerakiClientOptions.cs
+++ b/Meraki.Api/MerakiClientOptions.cs
@@ -44,26 +44,79 @@ public class MerakiClientOptions
 	public string? AccessToken { get; set; }
 
 	/// <summary>
-	/// Allow overriding the HttpClient Timeout - defaults to 600 seconds
+	/// The overall <see cref="HttpClient.Timeout"/> in seconds. Defaults to 600.
 	/// </summary>
+	/// <remarks>
+	/// This bounds a single logical call <b>including every retry and back-off wait</b>, so at the
+	/// default retry settings it is this timeout, not <see cref="MaxAttemptCount"/>, that ends a request
+	/// the API keeps throttling. It surfaces as a <see cref="TaskCanceledException"/> from
+	/// <see cref="HttpClient"/>. For the timeout applied to each individual attempt see
+	/// <see cref="HttpClientInnerTimeoutSeconds"/>. See <see cref="MaxAttemptCount"/> for how the
+	/// retry options fit together.
+	/// </remarks>
 	public int HttpClientTimeoutSeconds { get; set; } = 600;
 
 	/// <summary>
-	/// When a 429 HttpStatus code is sent, the back-off duration doubles on each attempt.
-	/// This option sets the maximum back-off duration. Defaults to 30
+	/// The longest the client will wait between attempts, in seconds. Defaults to 30.
 	/// </summary>
+	/// <remarks>
+	/// Caps the delay computed from <see cref="BackOffDelayFactor"/> and the server's
+	/// <c>Retry-After</c> header, and also caps the jitter added to that delay. It is the ceiling on
+	/// growth, not the cause of it: with the default <see cref="BackOffDelayFactor"/> of 1.0 the delay
+	/// does not grow at all, so this cap only comes into play where <c>Retry-After</c> exceeds it. See
+	/// <see cref="MaxAttemptCount"/> for how the retry options fit together.
+	/// </remarks>
 	public int MaxBackOffDelaySeconds { get; set; } = 30;
 
 	/// <summary>
-	/// This is the exponential factor by which the API Retry-After duration is increased on each attempt.
-	/// e.g. 1.0 = no change, 1.5 = 50% increase, 2.0 = double
-	/// Defaults to 1.0
+	/// The base of the exponential back-off between attempts. Defaults to 1.0, which is a flat delay.
 	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Before attempt <i>n</i> the client waits
+	/// <c>min(max(BackOffDelayFactor^(n-1), Retry-After), MaxBackOffDelaySeconds)</c> seconds, plus a
+	/// small upward jitter. The exponential term never falls below one second and is measured in
+	/// seconds, so it is independent of <c>Retry-After</c> rather than a multiplier on it.
+	/// </para>
+	/// <para>
+	/// At the default of 1.0 the exponential term is always exactly one second, so the wait is simply
+	/// <c>Retry-After</c> (or one second where the server sends none), capped at
+	/// <see cref="MaxBackOffDelaySeconds"/>. This is deliberate: see <see cref="MaxAttemptCount"/>.
+	/// A value of 2.0 doubles the delay on every attempt until it reaches the cap; 1.5 grows it by half.
+	/// </para>
+	/// </remarks>
 	public double BackOffDelayFactor { get; set; } = 1.0;
 
 	/// <summary>
-	/// When retrying
+	/// The maximum number of attempts made for a single call before the client gives up. Defaults to 500.
 	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Applies to HTTP 429 and 502/503/504 responses, to per-attempt timeouts
+	/// (<see cref="HttpClientInnerTimeoutSeconds"/>) and to transient connection failures. Other status
+	/// codes are returned to the caller on the first attempt. When attempts run out the client returns
+	/// the last response, so Refit raises an ordinary <see cref="ApiException"/> carrying that status.
+	/// </para>
+	/// <para>
+	/// <b>Why the defaults are 500 attempts with a flat, roughly one-second delay.</b> Meraki's rate
+	/// limit is per organization and is shared with every other consumer of that organization's API,
+	/// including monitoring tools such as Splunk that poll it aggressively. Against a saturated
+	/// organization, growing back-off is counter-productive: the longer this client waits, the more of
+	/// the budget the other consumers take. The most reliable way to get a call through is to keep
+	/// re-asking, honouring <c>Retry-After</c> each time, until a slot opens. The defaults are therefore
+	/// tuned so that a call <i>most likely completes</i>, at the cost of possibly taking a long time.
+	/// </para>
+	/// <para>
+	/// The practical bound on that time is <see cref="HttpClientTimeoutSeconds"/> (default 600
+	/// seconds), which spans all attempts. At the defaults a throttled call ends with a
+	/// <see cref="TaskCanceledException"/> from that timeout before attempt 500 is ever reached.
+	/// </para>
+	/// <para>
+	/// <b>To fail fast instead</b>, lower <see cref="MaxAttemptCount"/> (for example to 5 or 10) and,
+	/// if you want the delay to grow between those attempts, set <see cref="BackOffDelayFactor"/> above
+	/// 1.0. Consider also lowering <see cref="HttpClientTimeoutSeconds"/> so the overall bound matches.
+	/// </para>
+	/// </remarks>
 	public int MaxAttemptCount { get; set; } = 500;
 
 	/// <summary>
@@ -93,9 +146,14 @@ public class MerakiClientOptions
 	public Action<Type, JsonSerializationException, string>? JsonMissingMemberAction { get; set; }
 
 	/// <summary>
-	/// The inner HttpClient timeout in seconds.  This is used to set the Timeout on the inner HttpClient used to make requests.
-	/// Increase this if you are making requests that take a long time to complete.
+	/// The timeout applied to each individual attempt, in seconds. Defaults to 25.
 	/// </summary>
+	/// <remarks>
+	/// An attempt that exceeds this is abandoned, waited out using the back-off settings, and retried
+	/// up to <see cref="MaxAttemptCount"/> times, after which a <see cref="TimeoutException"/> is thrown.
+	/// Increase this if you call endpoints that legitimately take a long time to respond. Contrast with
+	/// <see cref="HttpClientTimeoutSeconds"/>, which bounds the whole call across all attempts.
+	/// </remarks>
 	public double HttpClientInnerTimeoutSeconds { get; set; } = 25;
 
 	/// <summary>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Meraki.Api
+﻿# Meraki.Api
 
 [![Nuget](https://img.shields.io/nuget/v/Meraki.Api)](https://www.nuget.org/packages/Meraki.Api/)
 [![Nuget](https://img.shields.io/nuget/dt/Meraki.Api)](https://www.nuget.org/packages/Meraki.Api/)
@@ -163,6 +163,52 @@ These come from Cisco's own documentation, and are worth reading before you desi
   connection times out.
 - **Rate limits are shared.** The server respects the Dashboard limit of 10 requests per second per
   organization, and that budget is shared with any `MerakiClient` traffic in the same process.
+
+## Retries, back-off and rate limiting
+
+Meraki's Dashboard API rate limit is **per organization**, and it is shared with every other
+consumer of that organization's API: other applications, scripts, and monitoring tools such as Splunk
+that poll aggressively. When the limit is hit the API answers `429 Too Many Requests` with a
+`Retry-After` header.
+
+`MerakiClient` retries 429s (and 502/503/504s, per-attempt timeouts and transient connection
+failures) transparently. The relevant `MerakiClientOptions` are:
+
+| Option | Default | Meaning |
+|---|---|---|
+| `MaxAttemptCount` | 500 | Attempts per call before giving up |
+| `BackOffDelayFactor` | 1.0 | Base of the exponential back-off. 1.0 is a flat delay |
+| `MaxBackOffDelaySeconds` | 30 | Ceiling on any single wait |
+| `HttpClientInnerTimeoutSeconds` | 25 | Timeout for one attempt |
+| `HttpClientTimeoutSeconds` | 600 | Timeout for the whole call, spanning all attempts and waits |
+
+Before attempt *n* the client waits `min(max(BackOffDelayFactor^(n-1), Retry-After), MaxBackOffDelaySeconds)`
+seconds plus a small upward jitter. At the default factor of 1.0 that is simply `Retry-After`, or one
+second where the server sends none.
+
+**The defaults are deliberately persistent.** Against a saturated organization, growing back-off is
+counter-productive: the longer this client waits, the more of the shared budget the other consumers
+take. The most reliable way to get a call through is to keep re-asking, honouring `Retry-After`,
+until a slot opens. So out of the box a call *most likely completes*, at the cost of possibly taking a
+long time. In practice the bound on that time is `HttpClientTimeoutSeconds`, which ends a still-throttled
+call with a `TaskCanceledException` long before attempt 500 is reached.
+
+**To fail fast instead**, override the defaults:
+
+```csharp
+var client = new MerakiClient(new MerakiClientOptions
+{
+    ApiKey = apiKey,
+    UserAgent = "YourProduct/1.0 YourCompany",
+    MaxAttemptCount = 5,          // give up after five attempts
+    BackOffDelayFactor = 2.0,     // 1s, 2s, 4s, 8s between them (capped by MaxBackOffDelaySeconds)
+    HttpClientTimeoutSeconds = 60 // and never spend more than a minute on one call
+});
+```
+
+When attempts run out the client returns the last response, so Refit raises an ordinary `ApiException`
+carrying that status (typically 429). Per-attempt timeouts that run out of attempts throw
+`TimeoutException`.
 
 ## API Documentation
 


### PR DESCRIPTION
Closes #378

## What

Documentation only. **No default or behaviour changed.**

- `MerakiClientOptions` XML docs for `HttpClientTimeoutSeconds`, `MaxBackOffDelaySeconds`, `BackOffDelayFactor`, `MaxAttemptCount` and `HttpClientInnerTimeoutSeconds` now describe what actually happens, including the exact delay formula and the interaction the issue describes (at the defaults, `HttpClientTimeoutSeconds` ends a throttled call, not `MaxAttemptCount`).
- README gains a "Retries, back-off and rate limiting" section with an options table, the rationale for the defaults, and a fail-fast example.
- CHANGELOG entry.

## Why the defaults stay

The issue proposes lowering `MaxAttemptCount` and raising `BackOffDelayFactor`. We are keeping the defaults deliberately. Meraki's limit is per organization and shared with every other consumer of that organization, including monitoring tools such as Splunk that poll aggressively. Against a saturated organization, growing back-off hands more of the budget to the other consumers; the reliable way to get a call through is to keep re-asking while honouring `Retry-After`. The defaults are tuned so a call most likely completes. Consumers who prefer to fail fast override the options, and the docs now show how.

The issue's two factual points are addressed: the misleading "doubles on each attempt" comment is gone, and the `MaxAttemptCount` / `HttpClientTimeoutSeconds` interaction is documented prominently in both places.

## Verification

`dotnet build Meraki.Api` succeeds with no XML documentation warnings (all `<see cref>` targets resolve).