### PR TITLE
fix: validate MerakiClientOptions in the MerakiClient constructor (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- `MerakiClient` now calls `MerakiClientOptions.Validate()` in its constructor
+  (issue [#377](https://github.com/panoramicdata/Meraki.Api/issues/377)). Previously only
+  `MerakiMcpClient` validated its options, so the two clients disagreed about what a valid
+  configuration was: a `MerakiClient` with no credentials was accepted and failed on its first request
+  with `InvalidOperationException`, one with both `ApiKey` and `AccessToken` set was accepted silently,
+  and negative timeouts reached `CancellationTokenSource`. All of these now throw
+  `ConfigurationException` from `new MerakiClient(...)`. `Validate()` additionally rejects
+  `MaxAttemptCount` below 1 (which silently disabled retries) and `HttpClientTimeoutSeconds` of zero or
+  less. **Behaviour change:** a client built with an empty `ApiKey` now fails at construction rather
+  than on first use. Such a client could never have made a successful call, but code that constructs
+  clients speculatively, before a key is known, should now construct them lazily.
+
 - Documented how the retry options interact and why the defaults are what they are
   (issue [#378](https://github.com/panoramicdata/Meraki.Api/issues/378)). The XML comment on
   `MaxBackOffDelaySeconds` claimed the back-off "doubles on each attempt", which describes

--- a/Meraki.Api.Test/MerakiClientOptionsTests.cs
+++ b/Meraki.Api.Test/MerakiClientOptionsTests.cs
@@ -1,0 +1,92 @@
+using Meraki.Api.Exceptions;
+
+namespace Meraki.Api.Test;
+
+/// <summary>
+/// Tests for <see cref="MerakiClientOptions.Validate"/> and for the <see cref="MerakiClient"/>
+/// constructor calling it
+/// (<see href="https://github.com/panoramicdata/Meraki.Api/issues/377">issue 377</see>).
+/// None of these need credentials or a network.
+/// </summary>
+public class MerakiClientOptionsTests
+{
+	private static MerakiClientOptions Valid() => new()
+	{
+		ApiKey = "0000000000000000000000000000000000000000",
+		UserAgent = "Meraki.Api.Test/1.0"
+	};
+
+	[Fact]
+	public void Validate_WithApiKeyAndDefaults_DoesNotThrow()
+	{
+		var act = () => Valid().Validate();
+
+		_ = act.Should().NotThrow();
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Validate_WithMaxAttemptCountBelowOne_Throws(int maxAttemptCount)
+	{
+		var options = Valid();
+		options.MaxAttemptCount = maxAttemptCount;
+
+		var act = () => options.Validate();
+
+		_ = act.Should().Throw<ConfigurationException>().WithMessage($"*{nameof(MerakiClientOptions.MaxAttemptCount)}*");
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Validate_WithHttpClientTimeoutSecondsNotPositive_Throws(int httpClientTimeoutSeconds)
+	{
+		var options = Valid();
+		options.HttpClientTimeoutSeconds = httpClientTimeoutSeconds;
+
+		var act = () => options.Validate();
+
+		_ = act.Should().Throw<ConfigurationException>().WithMessage($"*{nameof(MerakiClientOptions.HttpClientTimeoutSeconds)}*");
+	}
+
+	[Fact]
+	public void Constructor_WithNoCredentials_ThrowsConfigurationException()
+	{
+		var options = new MerakiClientOptions { UserAgent = "Meraki.Api.Test/1.0" };
+
+		var act = () => new MerakiClient(options);
+
+		_ = act.Should().Throw<ConfigurationException>();
+	}
+
+	[Fact]
+	public void Constructor_WithBothApiKeyAndAccessToken_ThrowsConfigurationException()
+	{
+		var options = Valid();
+		options.AccessToken = "oauth-token";
+
+		var act = () => new MerakiClient(options);
+
+		_ = act.Should().Throw<ConfigurationException>();
+	}
+
+	[Fact]
+	public void Constructor_WithNegativeHttpClientInnerTimeoutSeconds_ThrowsConfigurationException()
+	{
+		var options = Valid();
+		options.HttpClientInnerTimeoutSeconds = -1;
+
+		var act = () => new MerakiClient(options);
+
+		_ = act.Should().Throw<ConfigurationException>();
+	}
+
+	[Fact]
+	public void Constructor_WithValidOptions_Succeeds()
+	{
+		using var client = new MerakiClient(Valid());
+
+		_ = client.Should().NotBeNull();
+	}
+}

--- a/Meraki.Api/MerakiClient.cs
+++ b/Meraki.Api/MerakiClient.cs
@@ -78,14 +78,19 @@ public partial class MerakiClient : IDisposable
 	/// <summary>
 	/// A Meraki portal client
 	/// </summary>
+	/// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+	/// <exception cref="ConfigurationException"><paramref name="options"/> fails <see cref="MerakiClientOptions.Validate"/>.</exception>
 	public MerakiClient(MerakiClientOptions options, ILogger? logger = default)
 	{
+		ArgumentNullException.ThrowIfNull(options);
+		options.Validate();
+
 		var apiClientVersion = new System.Version(ThisAssembly.AssemblyFileVersion);
 		ApiClientVersion = $"{apiClientVersion.Major}.{apiClientVersion.Minor}.{apiClientVersion.Build}";
 
 		_options = options;
 		_logger = logger ?? NullLogger.Instance;
-		_httpClientHandler = new AuthenticatedBackingOffHttpClientHandler(options ?? throw new ArgumentNullException(nameof(options)), this, _logger);
+		_httpClientHandler = new AuthenticatedBackingOffHttpClientHandler(options, this, _logger);
 
 		var merakiDomain = options.ApiRegion.GetMerakiApiDomain()
 			?? throw new ArgumentOutOfRangeException($"Unsupported API Region {options.ApiRegion}");

--- a/Meraki.Api/MerakiClientOptions.cs
+++ b/Meraki.Api/MerakiClientOptions.cs
@@ -186,5 +186,16 @@ public class MerakiClientOptions
 		{
 			throw new ConfigurationException($"{nameof(HttpClientInnerTimeoutSeconds)} should not be less than zero.");
 		}
+
+		if (HttpClientTimeoutSeconds <= 0)
+		{
+			throw new ConfigurationException($"{nameof(HttpClientTimeoutSeconds)} should be greater than zero.");
+		}
+
+		// Zero or negative would make the retry guard true on the first pass, so no attempt would ever be retried.
+		if (MaxAttemptCount < 1)
+		{
+			throw new ConfigurationException($"{nameof(MaxAttemptCount)} should be at least one.");
+		}
 	}
 }


### PR DESCRIPTION
Closes #377

## What

- `MerakiClient` constructor now does `ArgumentNullException.ThrowIfNull(options); options.Validate();` before anything else.
- `Validate()` gains two rules: `MaxAttemptCount >= 1` and `HttpClientTimeoutSeconds > 0`.
- The duplicate authentication check in `AuthenticatedBackingOffHttpClientHandler.EnsureRequestIsPermitted` is **kept**: the handler is constructable on its own (the workflows tests do so), so it still needs to defend itself.

## Behaviour change

A `MerakiClient` built with an empty `ApiKey` (and no `AccessToken`) now throws `ConfigurationException` at construction instead of `InvalidOperationException` on first request. Such a client could never have made a successful call. Code that constructs clients speculatively before a key is known should construct them lazily.

Downstream check (DNA.Assure, DNA.WiserWatts, Cae.Portal): every construction site sets a non-empty `ApiKey`, none sets `AccessToken`, none sets negative or zero values. `MaxAttemptCount` is set to 5, 15, 50, 300 or 900 where overridden. No known consumer is affected, with one caveat: Cae.Portal builds a client per estate from a stored key, so an estate with no key configured would now fail earlier and with a clearer exception.

## Tests

`MerakiClientOptionsTests` (new, credential-free): 9 tests covering each new rule via `Validate()` and each class of rule via the constructor. Written first; 7 failed against `main`, all pass after. The existing wiring, workflows and MCP unit tests (206 total) still pass.