### PR TITLE
fix: let the caller's CancellationToken abort an in-flight HTTP attempt (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- A caller's `CancellationToken` now **aborts an in-flight HTTP attempt** immediately
+  (issue [#391](https://github.com/panoramicdata/Meraki.Api/issues/391)). Each attempt was sent with
+  only the handler's own per-attempt timeout token, so although every wait *between* attempts already
+  honoured the caller's token, cancelling during an attempt still meant waiting out the rest of
+  `HttpClientInnerTimeoutSeconds` (default 25 seconds). The per-attempt token is now linked to the
+  caller's, so either ends the attempt. Timeout detection is unchanged: an attempt that ends because of
+  the inner timeout is still retried, and one that ends because the caller cancelled still surfaces as
+  `OperationCanceledException`. Note that cancellation observed between attempts throws a plain
+  `OperationCanceledException`, while cancellation observed inside `HttpClient` throws its subclass
+  `TaskCanceledException`; consumers should catch the base type.
+
 - `MerakiClient` now calls `MerakiClientOptions.Validate()` in its constructor
   (issue [#377](https://github.com/panoramicdata/Meraki.Api/issues/377)). Previously only
   `MerakiMcpClient` validated its options, so the two clients disagreed about what a valid

--- a/Meraki.Api.Test/Client/CancellationTests.cs
+++ b/Meraki.Api.Test/Client/CancellationTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
+
+namespace Meraki.Api.Test.Client;
+
+/// <summary>
+/// Cancellation behaviour of <see cref="AuthenticatedBackingOffHttpClientHandler"/>
+/// (<see href="https://github.com/panoramicdata/Meraki.Api/issues/391">issue 391</see>).
+/// The inner handler never answers, so the only way out of an attempt is a token.
+/// No credentials or network are needed.
+/// </summary>
+public class CancellationTests
+{
+	private static readonly Uri RequestUri = new("https://api.meraki.com/api/v1/organizations");
+
+	private static (HttpClient HttpClient, HangingHandler Inner) CreateClient(MerakiClientOptions options)
+	{
+		var inner = new HangingHandler();
+		var merakiClient = new MerakiClient(options);
+		var transport = new AuthenticatedBackingOffHttpClientHandler(options, merakiClient, NullLogger.Instance, inner);
+		return (new HttpClient(transport), inner);
+	}
+
+	[Fact]
+	public async Task CallerCancellation_AbortsAnInFlightAttempt_WithoutWaitingForTheInnerTimeout()
+	{
+		var options = new MerakiClientOptions
+		{
+			ApiKey = "0000000000000000000000000000000000000000",
+			UserAgent = "Meraki.Api.Test/1.0",
+			HttpClientInnerTimeoutSeconds = 5,
+			MaxAttemptCount = 1
+		};
+		var (httpClient, inner) = CreateClient(options);
+		using var callerCancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+		var stopwatch = Stopwatch.StartNew();
+
+		var act = () => httpClient.GetAsync(RequestUri, callerCancellation.Token);
+
+		_ = await act.Should().ThrowAsync<OperationCanceledException>();
+		stopwatch.Stop();
+		_ = stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2),
+			"the caller cancelled after 200ms and should not have to wait out the 5s inner timeout");
+		_ = inner.Attempts.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task InnerTimeout_StillRetriesAndThenThrowsTimeoutException_WhenTheCallerHasNotCancelled()
+	{
+		var options = new MerakiClientOptions
+		{
+			ApiKey = "0000000000000000000000000000000000000000",
+			UserAgent = "Meraki.Api.Test/1.0",
+			HttpClientInnerTimeoutSeconds = 0.2,
+			MaxAttemptCount = 2,
+			MaxBackOffDelaySeconds = 0
+		};
+		var (httpClient, inner) = CreateClient(options);
+
+		var act = () => httpClient.GetAsync(RequestUri, TestContext.Current.CancellationToken);
+
+		_ = await act.Should().ThrowAsync<TimeoutException>();
+		_ = inner.Attempts.Should().Be(2);
+	}
+
+	/// <summary>
+	/// Never responds. Completes only when the token it was handed is cancelled.
+	/// </summary>
+	private sealed class HangingHandler : HttpMessageHandler
+	{
+		public int Attempts { get; private set; }
+
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			Attempts++;
+			await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+			throw new InvalidOperationException("Unreachable");
+		}
+	}
+}

--- a/Meraki.Api/AuthenticatedBackingOffHttpClientHandler.cs
+++ b/Meraki.Api/AuthenticatedBackingOffHttpClientHandler.cs
@@ -63,8 +63,11 @@ internal sealed class AuthenticatedBackingOffHttpClientHandler : DelegatingHandl
 
 			LastRequestUri = request.RequestUri?.ToString() ?? string.Empty;
 
-			// Create a new CancellationToken derived from the original, but with a timeout
-			using var timeoutCancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(_options.HttpClientInnerTimeoutSeconds));
+			// Derive the per-attempt token from the caller's token, then add the inner timeout, so
+			// that either can abort the attempt. The catch filter in TrySendAsync tells the two
+			// apart: it treats the failure as a timeout only when the caller has not cancelled.
+			using var timeoutCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			timeoutCancellationSource.CancelAfter(TimeSpan.FromSeconds(_options.HttpClientInnerTimeoutSeconds));
 
 			// A null response means the attempt failed in a way that has already been logged and waited out.
 			var httpResponseMessage = await TrySendAsync(


### PR DESCRIPTION
Closes #391

## What

In `AuthenticatedBackingOffHttpClientHandler.SendAsync`, the per-attempt timeout source is now `CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)` with `CancelAfter(HttpClientInnerTimeoutSeconds)`, instead of a standalone `CancellationTokenSource(timeout)`. Two lines of production change.

## Why

Every wait *between* attempts already honoured the caller's token, but the attempt itself was sent with only the handler's own timeout token. A caller that cancelled mid-attempt waited out the remainder of the inner timeout (default 25s) before seeing `OperationCanceledException`.

The existing catch filter in `TrySendAsync` (`when (timeoutToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)`) already distinguishes the two causes and is unchanged, so the timeout-retry path behaves exactly as before.

## Downstream

Positive only. DNA.Assure's `MerakiInventoryGateway.IsCallerCancellation` keys off `cancellationToken.IsCancellationRequested` and continues to work. Cae.Portal's job watchdog (CAEP-2311) exists because cooperative cancellation did not always unblock a hung call; this closes one of the reasons. DNA.WiserWatts's `OrganizationWorker.StopAsync` awaits in-flight work without a timeout and benefits directly.

## Tests

`Meraki.Api.Test/Client/CancellationTests.cs` (new, credential-free). Uses the handler's internal constructor with an inner `HttpMessageHandler` that never responds:

- `CallerCancellation_AbortsAnInFlightAttempt_WithoutWaitingForTheInnerTimeout`: caller cancels at 200ms with a 5s inner timeout; asserts `OperationCanceledException` within 2s. **Failed on `main` at 5.0s**, passes now at ~200ms.
- `InnerTimeout_StillRetriesAndThenThrowsTimeoutException_WhenTheCallerHasNotCancelled`: regression guard for the timeout-retry path; passes before and after.

56 credential-free unit tests across the handler, workflows and wiring suites pass.