### PR TITLE
fix: follow tolerant rel=next links and throw when a next page cannot be followed (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Pagination **no longer stops silently** when a response advertises a next page that the client
+  cannot follow (issue [#356](https://github.com/panoramicdata/Meraki.Api/issues/356)). The
+  `GetAll*Async` helpers required the `rel=next` Link segment to split into exactly two parts on `;`,
+  so a segment with any additional attribute (for example a `title`) was treated as "no next page" and
+  the pages fetched so far were returned as a complete, successful result. The caller had no way to
+  tell that list from a genuinely complete one. The parser now takes the first component as the URL
+  and scans the rest for the `rel` attribute (quoted or not), so such links are followed. Where a
+  `rel=next` link is present but its URL is missing or not absolute, the helpers throw the new
+  `PaginationException` instead of returning truncated data, because a caller can retry but cannot
+  detect a silent shortfall. The Link parser is now shared with the `QueryAsync` auto-pagination,
+  which had the same silent-stop path. Two or more `rel=next` segments no longer throw
+  `InvalidOperationException`; the first is used.
+
 - A caller's `CancellationToken` now **aborts an in-flight HTTP attempt** immediately
   (issue [#391](https://github.com/panoramicdata/Meraki.Api/issues/391)). Each attempt was sent with
   only the handler's own per-attempt timeout token, so although every wait *between* attempts already

--- a/Meraki.Api.Test/MerakiClientPagerTests.cs
+++ b/Meraki.Api.Test/MerakiClientPagerTests.cs
@@ -1,0 +1,108 @@
+﻿using Meraki.Api.Exceptions;
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Meraki.Api.Test;
+
+/// <summary>
+/// Link-header parsing and page-following behaviour of the pagination helpers
+/// (<see href="https://github.com/panoramicdata/Meraki.Api/issues/356">issue 356</see>).
+/// No credentials or network are needed.
+/// </summary>
+public class MerakiClientPagerTests
+{
+	private const string Page2Url = "https://api.meraki.com/api/v1/organizations/123/devices?perPage=1000&startingAfter=Q2XX";
+
+	private static HttpResponseHeaders HeadersWithLink(string link)
+	{
+		var response = new HttpResponseMessage();
+		_ = response.Headers.TryAddWithoutValidation("Link", link);
+		return response.Headers;
+	}
+
+	[Fact]
+	public void GetNextPageUri_WithExtraLinkAttribute_StillReturnsTheNextUri()
+	{
+		var headers = HeadersWithLink($"<{Page2Url}>; rel=next; title=\"next page\"");
+
+		var next = MerakiClient.GetNextPageUri(headers);
+
+		_ = next.Should().Be(new Uri(Page2Url));
+	}
+
+	[Fact]
+	public void GetNextPageUri_WithQuotedRelValue_StillReturnsTheNextUri()
+	{
+		var headers = HeadersWithLink($"<{Page2Url}>; rel=\"next\"");
+
+		var next = MerakiClient.GetNextPageUri(headers);
+
+		_ = next.Should().Be(new Uri(Page2Url));
+	}
+
+	[Fact]
+	public void GetNextPageUri_WithTwoNextSegments_ReturnsTheFirstRatherThanThrowing()
+	{
+		var headers = HeadersWithLink($"<{Page2Url}>; rel=next, <https://api.meraki.com/api/v1/other>; rel=next");
+
+		var next = MerakiClient.GetNextPageUri(headers);
+
+		_ = next.Should().Be(new Uri(Page2Url));
+	}
+
+	[Theory]
+	[InlineData("<>; rel=next")]
+	[InlineData("<not a url>; rel=next")]
+	[InlineData("<organizations/123/devices?startingAfter=Q2XX>; rel=next")]
+	public void GetNextPageUri_WithNextLinkThatCannotBeFollowed_Throws(string link)
+	{
+		var headers = HeadersWithLink(link);
+
+		var act = () => MerakiClient.GetNextPageUri(headers);
+
+		_ = act.Should().Throw<PaginationException>().WithMessage("*rel=next*");
+	}
+
+	[Fact]
+	public async Task GetAllAsync_FollowsANextLinkThatCarriesExtraAttributes()
+	{
+		var pagesRequested = new List<string?>();
+
+		var all = await MerakiClient.GetAllAsync<string>(
+			(startingAfter, _, _) =>
+			{
+				pagesRequested.Add(startingAfter);
+				return Task.FromResult(startingAfter is null
+					? Page(["a", "b"], $"<{Page2Url}>; rel=next; title=\"next page\"")
+					: Page(["c"], link: null));
+			},
+			TestContext.Current.CancellationToken);
+
+		_ = all.Should().Equal("a", "b", "c");
+		_ = pagesRequested.Should().Equal(null, "Q2XX");
+	}
+
+	[Fact]
+	public async Task GetAllAsync_WithANextLinkThatCannotBeFollowed_ThrowsRatherThanReturningTruncatedData()
+	{
+		var act = () => MerakiClient.GetAllAsync<string>(
+			(_, _, _) => Task.FromResult(Page(["a", "b"], "<not a url>; rel=next")),
+			TestContext.Current.CancellationToken);
+
+		_ = await act.Should().ThrowAsync<PaginationException>();
+	}
+
+	private static ApiResponse<List<string>> Page(List<string> items, string? link)
+	{
+		var response = new HttpResponseMessage(HttpStatusCode.OK)
+		{
+			RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://api.meraki.com/api/v1/organizations/123/devices")
+		};
+		if (link is not null)
+		{
+			_ = response.Headers.TryAddWithoutValidation("Link", link);
+		}
+
+		return new ApiResponse<List<string>>(response, items, new RefitSettings());
+	}
+}

--- a/Meraki.Api/Exceptions/PaginationException.cs
+++ b/Meraki.Api/Exceptions/PaginationException.cs
@@ -1,0 +1,35 @@
+namespace Meraki.Api.Exceptions;
+
+/// <summary>
+/// Thrown when a paginated response advertises a next page in its <c>Link</c> header that the
+/// client cannot follow. Failing loudly is safer than returning the pages fetched so far as a
+/// complete result, because a caller can retry but cannot detect a silently truncated list.
+/// </summary>
+public class PaginationException : Exception
+{
+	/// <summary>
+	/// Initializes a new instance of the PaginationException class
+	/// </summary>
+	public PaginationException()
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the PaginationException class with a specified error message
+	/// </summary>
+	/// <param name="message">The message that describes the error</param>
+	public PaginationException(string message)
+		: base(message)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the PaginationException class with a specified error message and inner exception
+	/// </summary>
+	/// <param name="message">The message that describes the error</param>
+	/// <param name="innerException">The exception that is the cause of the current exception</param>
+	public PaginationException(string message, Exception innerException)
+		: base(message, innerException)
+	{
+	}
+}

--- a/Meraki.Api/MerakiClient.Query.cs
+++ b/Meraki.Api/MerakiClient.Query.cs
@@ -183,9 +183,18 @@ public partial class MerakiClient
 	/// requested directly (it stays on the same api domain, so it still flows through the
 	/// authenticated, rate-limited handler).
 	/// </summary>
-	internal static Uri? GetNextPageUri(HttpResponseHeaders headers)
+	/// <remarks>
+	/// "No next link" and "a next link I cannot follow" are deliberately different outcomes. The
+	/// first is how the API signals the last page. The second means the API has said there is more
+	/// data and the client cannot fetch it, so returning null there would hand the caller a truncated
+	/// list that looks complete. Each Link segment is <c>&lt;url&gt;; attr; attr...</c>: the first
+	/// component is the URL and the rest are attributes, of which only <c>rel</c> is inspected, with
+	/// or without quotes.
+	/// </remarks>
+	/// <exception cref="PaginationException">A rel=next link is present but its URL is missing or not absolute.</exception>
+	internal static Uri? GetNextPageUri(HttpHeaders? headers)
 	{
-		if (!headers.TryGetValues("Link", out var linkHeaders))
+		if (headers is null || !headers.TryGetValues("Link", out var linkHeaders))
 		{
 			return null;
 		}
@@ -198,22 +207,27 @@ public partial class MerakiClient
 
 		var nextLink = linkHeader
 			.Split(',')
-			.FirstOrDefault(link => link.Contains("rel=next"));
+			.FirstOrDefault(IsNextLink);
 		if (nextLink is null)
 		{
 			return null;
 		}
 
-		var components = nextLink.Split(';');
-		if (components.Length < 2)
-		{
-			return null;
-		}
-
-		var url = components[0].Trim().TrimStart('<').TrimEnd('>');
+		var url = nextLink.Split(';')[0].Trim().TrimStart('<').TrimEnd('>');
 		return Uri.TryCreate(url, UriKind.Absolute, out var uri)
 			? uri
-			: null;
+			: throw new PaginationException(
+				$"The response advertised a further page (Link: rel=next) but its URL could not be parsed, so the results would be incomplete. Link header: {linkHeader}");
 	}
+
+	/// <summary>
+	/// True where a single Link segment carries a rel attribute of "next", quoted or not.
+	/// </summary>
+	private static bool IsNextLink(string linkSegment)
+		=> linkSegment
+			.Split(';')
+			.Skip(1)
+			.Select(attribute => attribute.Replace("\"", string.Empty).Replace(" ", string.Empty))
+			.Any(attribute => attribute.Equals("rel=next", StringComparison.OrdinalIgnoreCase));
 }
 #pragma warning restore S2333

--- a/Meraki.Api/MerakiClientPager.cs
+++ b/Meraki.Api/MerakiClientPager.cs
@@ -13,41 +13,15 @@ public partial class MerakiClient
 {
 	/// <summary>
 	/// Reads the query string of the "rel=next" link in the response headers, or null where there
-	/// is no next page to fetch.
+	/// is no next page to fetch. Throws <see cref="PaginationException"/> where a next page is
+	/// advertised but cannot be followed; see <see cref="GetNextPageUri"/>.
 	/// </summary>
 	private static NameValueCollection? TryGetNextPageQuery(HttpHeaders? headers)
 	{
-		// Check the Link response header
-		if (headers is null || !headers.TryGetValues("Link", out var linkHeaders))
-		{
-			return null;
-		}
-
-		// We found a Link header
-		var linkHeader = linkHeaders.FirstOrDefault();
-		if (linkHeader is null)
-		{
-			return null;
-		}
-
-		// We need the next link, which might have startingAfter or endingBefore defined
-		var nextLink = linkHeader
-			.Split(',')
-			.SingleOrDefault(link => link.Contains("rel=next"));
-		if (nextLink is null)
-		{
-			return null;
-		}
-
-		var nextLinkComponents = nextLink.Split(';');
-		if (nextLinkComponents.Length != 2)
-		{
-			return null;
-		}
-
-		// Get the url component and remove the < > wrapper
-		var nextLinkUrl = nextLinkComponents[0].Trim().TrimStart('<').TrimEnd('>');
-		return HttpUtility.ParseQueryString(new Uri(nextLinkUrl).Query);
+		var nextPageUri = GetNextPageUri(headers);
+		return nextPageUri is null
+			? null
+			: HttpUtility.ParseQueryString(nextPageUri.Query);
 	}
 
 	/// <summary>


### PR DESCRIPTION
Closes #356

## What

- `MerakiClient.GetNextPageUri` (previously used only by `QueryAsync` auto-pagination) is now the single Link-header parser, and the `GetAll*Async` pager delegates to it. Two parsers with slightly different bugs become one.
- Parsing is tolerant: the first `;`-component of the `rel=next` segment is the URL, the remaining components are attributes, and only `rel` is inspected, with or without quotes. `FirstOrDefault` replaces `SingleOrDefault`, so duplicate `rel=next` segments no longer throw `InvalidOperationException`.
- **"No next page" and "a next page I cannot follow" are now different outcomes.** The first still ends pagination normally. The second throws the new `PaginationException` (in `Meraki.Api.Exceptions`) rather than returning the pages fetched so far as a complete result.

## Why

At the shipped code, a `rel=next` segment with any extra attribute failed the `Length == 2` check and fell through to "finished", so the caller received a clean, non-empty, silently-short list. No defensive check on the calling side could detect it. Failing loudly is strictly safer: a caller can retry, but cannot detect a shortfall.

## Downstream

DNA.Assure, DNA.WiserWatts and Cae.Portal all use the `*AllAsync` helpers and none loops over Link headers themselves. The only behaviour they can observe is the new exception, and only in a case where today they would be handed truncated data as success. `PaginationException` derives from `Exception`, not `ApiException`, deliberately: it is a client-side parsing failure, not an HTTP failure, so status-code-driven retry logic (Assure's `ApiHelper`, Portal's `IsWorthRetrying`) correctly does not treat it as one. Meraki's real headers today are plain `<url>; rel=next`, so no consumer should see the exception in normal operation.

## Tests

`MerakiClientPagerTests` (new, credential-free), 8 tests:

- Parser: extra attribute followed, quoted `rel="next"` followed, duplicate `rel=next` uses the first, three unparseable-URL shapes throw `PaginationException`.
- Pager end to end via the static `GetAllAsync(ApiResponse)` overload: a next link with an extra attribute is followed and both pages are returned; an unparseable next link throws rather than returning page 1 as complete.

Six failed against `main` for the reasons above (the pager test returned one page and reported success). All 34 pager, query, wiring and workflows unit tests pass after the change.