### PR TITLE
feat: opt-in ThrowOnRetryExhaustion throws RetryExhaustedException (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- New opt-in `MerakiClientOptions.ThrowOnRetryExhaustion`
+  (issue [#375](https://github.com/panoramicdata/Meraki.Api/issues/375)). When every permitted attempt
+  ends in a retryable status (429, 502, 503 or 504), the client has always returned the final response,
+  so Refit raised an `ApiException` indistinguishable from a first-attempt failure with the same
+  status; the attempt count and time spent were logged but never reached the caller. With the option
+  set, the client instead throws `RetryExhaustedException`, carrying `StatusCode`, `AttemptCount`,
+  `MaxAttemptCount`, `Elapsed` (across every attempt and wait), `Method` and `RequestUri`.
+  **Defaults to false; nothing changes for existing consumers.** The new exception is deliberately not
+  an `ApiException`, so opt in only where that is what you want: code that catches `ApiException` and
+  inspects the status code will not see it. Only the 429/5xx exhaustion path is affected; timeouts
+  still throw `TimeoutException` and non-retryable statuses are still returned on the first attempt.
+
 - Pagination **no longer stops silently** when a response advertises a next page that the client
   cannot follow (issue [#356](https://github.com/panoramicdata/Meraki.Api/issues/356)). The
   `GetAll*Async` helpers required the `rel=next` Link segment to split into exactly two parts on `;`,

--- a/Meraki.Api.Test/Client/RetryExhaustionTests.cs
+++ b/Meraki.Api.Test/Client/RetryExhaustionTests.cs
@@ -1,0 +1,123 @@
+using Meraki.Api.Exceptions;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Net;
+
+namespace Meraki.Api.Test.Client;
+
+/// <summary>
+/// What the caller sees when every permitted attempt ends in a retryable status
+/// (<see href="https://github.com/panoramicdata/Meraki.Api/issues/375">issue 375</see>).
+/// No credentials or network are needed.
+/// </summary>
+public class RetryExhaustionTests
+{
+	private static readonly Uri RequestUri = new("https://api.meraki.com/api/v1/organizations");
+
+	private static MerakiClientOptions Options(int maxAttemptCount, bool throwOnRetryExhaustion) => new()
+	{
+		ApiKey = "0000000000000000000000000000000000000000",
+		UserAgent = "Meraki.Api.Test/1.0",
+		MaxAttemptCount = maxAttemptCount,
+		MaxBackOffDelaySeconds = 0,
+		ThrowOnRetryExhaustion = throwOnRetryExhaustion
+	};
+
+	private static (HttpClient HttpClient, FixedStatusHandler Inner) CreateClient(MerakiClientOptions options, HttpStatusCode status)
+	{
+		var inner = new FixedStatusHandler(status);
+		var merakiClient = new MerakiClient(options);
+		var transport = new AuthenticatedBackingOffHttpClientHandler(options, merakiClient, NullLogger.Instance, inner);
+		return (new HttpClient(transport), inner);
+	}
+
+	[Fact]
+	public void ThrowOnRetryExhaustion_DefaultsToFalse()
+		=> new MerakiClientOptions().ThrowOnRetryExhaustion.Should().BeFalse();
+
+	[Fact]
+	public async Task Exhaustion_ByDefault_ReturnsTheLastResponse()
+	{
+		var (httpClient, inner) = CreateClient(Options(maxAttemptCount: 3, throwOnRetryExhaustion: false), HttpStatusCode.TooManyRequests);
+
+		using var response = await httpClient.GetAsync(RequestUri, TestContext.Current.CancellationToken);
+
+		_ = response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+		_ = inner.Attempts.Should().Be(3);
+	}
+
+	[Fact]
+	public async Task Exhaustion_WhenOptedIn_ThrowsWithTheRetryDiagnostics()
+	{
+		var (httpClient, inner) = CreateClient(Options(maxAttemptCount: 3, throwOnRetryExhaustion: true), HttpStatusCode.TooManyRequests);
+
+		var act = () => httpClient.GetAsync(RequestUri, TestContext.Current.CancellationToken);
+
+		var exception = (await act.Should().ThrowAsync<RetryExhaustedException>()).Which;
+		_ = exception.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+		_ = exception.AttemptCount.Should().Be(3);
+		_ = exception.MaxAttemptCount.Should().Be(3);
+		_ = exception.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
+		_ = exception.Method.Should().Be(HttpMethod.Get);
+		_ = exception.RequestUri.Should().Be(RequestUri);
+		_ = exception.Message.Should().Contain("3/3").And.Contain("429");
+		_ = inner.Attempts.Should().Be(3);
+	}
+
+	[Theory]
+	[InlineData(HttpStatusCode.BadGateway)]
+	[InlineData(HttpStatusCode.ServiceUnavailable)]
+	[InlineData(HttpStatusCode.GatewayTimeout)]
+	public async Task Exhaustion_WhenOptedIn_AlsoThrowsForRetryableServerErrors(HttpStatusCode status)
+	{
+		// One attempt only: the 5xx path waits a fixed five seconds between attempts.
+		var (httpClient, _) = CreateClient(Options(maxAttemptCount: 1, throwOnRetryExhaustion: true), status);
+
+		var act = () => httpClient.GetAsync(RequestUri, TestContext.Current.CancellationToken);
+
+		var exception = (await act.Should().ThrowAsync<RetryExhaustedException>()).Which;
+		_ = exception.StatusCode.Should().Be(status);
+		_ = exception.AttemptCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task NonRetryableStatus_WhenOptedIn_IsStillReturnedToTheCaller()
+	{
+		var (httpClient, inner) = CreateClient(Options(maxAttemptCount: 3, throwOnRetryExhaustion: true), HttpStatusCode.NotFound);
+
+		using var response = await httpClient.GetAsync(RequestUri, TestContext.Current.CancellationToken);
+
+		_ = response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+		_ = inner.Attempts.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task Success_WhenOptedIn_IsStillReturnedToTheCaller()
+	{
+		var (httpClient, inner) = CreateClient(Options(maxAttemptCount: 3, throwOnRetryExhaustion: true), HttpStatusCode.OK);
+
+		using var response = await httpClient.GetAsync(RequestUri, TestContext.Current.CancellationToken);
+
+		_ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+		_ = inner.Attempts.Should().Be(1);
+	}
+
+	/// <summary>
+	/// Always answers with the same status, and Retry-After: 0 so the 429 path does not wait.
+	/// </summary>
+	private sealed class FixedStatusHandler(HttpStatusCode status) : HttpMessageHandler
+	{
+		public int Attempts { get; private set; }
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			Attempts++;
+			var response = new HttpResponseMessage(status)
+			{
+				RequestMessage = request,
+				Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json")
+			};
+			_ = response.Headers.TryAddWithoutValidation("Retry-After", "0");
+			return Task.FromResult(response);
+		}
+	}
+}

--- a/Meraki.Api/AuthenticatedBackingOffHttpClientHandler.cs
+++ b/Meraki.Api/AuthenticatedBackingOffHttpClientHandler.cs
@@ -52,6 +52,8 @@ internal sealed class AuthenticatedBackingOffHttpClientHandler : DelegatingHandl
 
 		var logPrefix = $"Request {Guid.NewGuid()}: ";
 		var attemptCount = 0;
+		// Spans every attempt and every wait, unlike _durationStopWatch which times one attempt.
+		var totalStopwatch = Stopwatch.StartNew();
 
 		while (true)
 		{
@@ -113,7 +115,22 @@ internal sealed class AuthenticatedBackingOffHttpClientHandler : DelegatingHandl
 						_options.MaxAttemptCount,
 						request.Method.ToString(),
 						request.RequestUri);
-					return httpResponseMessage;
+
+					if (!_options.ThrowOnRetryExhaustion)
+					{
+						return httpResponseMessage;
+					}
+
+					// The caller asked to be told about exhaustion explicitly rather than receive a
+					// response indistinguishable from a first-attempt failure.
+					httpResponseMessage.Dispose();
+					throw new RetryExhaustedException(
+						httpResponseMessage.StatusCode,
+						attemptCount,
+						_options.MaxAttemptCount,
+						totalStopwatch.Elapsed,
+						request.Method,
+						request.RequestUri);
 				}
 
 				_logger.LogInformation(

--- a/Meraki.Api/Exceptions/RetryExhaustedException.cs
+++ b/Meraki.Api/Exceptions/RetryExhaustedException.cs
@@ -1,0 +1,94 @@
+using System.Net;
+
+namespace Meraki.Api.Exceptions;
+
+/// <summary>
+/// Thrown, when <see cref="MerakiClientOptions.ThrowOnRetryExhaustion"/> is true, once every
+/// attempt permitted by <see cref="MerakiClientOptions.MaxAttemptCount"/> has ended in a retryable
+/// status (429, 502, 503 or 504). Carries the detail a caller needs to tell "throttled once" from
+/// "throttled for ten minutes", which the bare status code cannot convey.
+/// </summary>
+public class RetryExhaustedException : Exception
+{
+	/// <summary>
+	/// Initializes a new instance of the RetryExhaustedException class
+	/// </summary>
+	public RetryExhaustedException()
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the RetryExhaustedException class with a specified error message
+	/// </summary>
+	/// <param name="message">The message that describes the error</param>
+	public RetryExhaustedException(string message)
+		: base(message)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the RetryExhaustedException class with a specified error message and inner exception
+	/// </summary>
+	/// <param name="message">The message that describes the error</param>
+	/// <param name="innerException">The exception that is the cause of the current exception</param>
+	public RetryExhaustedException(string message, Exception innerException)
+		: base(message, innerException)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the RetryExhaustedException class with the retry diagnostics
+	/// </summary>
+	/// <param name="statusCode">The status of the final attempt</param>
+	/// <param name="attemptCount">The number of attempts made</param>
+	/// <param name="maxAttemptCount">The configured maximum</param>
+	/// <param name="elapsed">The time spent across every attempt and wait</param>
+	/// <param name="method">The HTTP method</param>
+	/// <param name="requestUri">The request URI</param>
+	public RetryExhaustedException(
+		HttpStatusCode statusCode,
+		int attemptCount,
+		int maxAttemptCount,
+		TimeSpan elapsed,
+		HttpMethod method,
+		Uri? requestUri)
+		: base($"Giving up after {attemptCount}/{maxAttemptCount} attempts over {elapsed.TotalSeconds:N1}s; the last response was {(int)statusCode} {statusCode}. ({method} - {requestUri})")
+	{
+		StatusCode = statusCode;
+		AttemptCount = attemptCount;
+		MaxAttemptCount = maxAttemptCount;
+		Elapsed = elapsed;
+		Method = method;
+		RequestUri = requestUri;
+	}
+
+	/// <summary>
+	/// The status of the final attempt
+	/// </summary>
+	public HttpStatusCode StatusCode { get; }
+
+	/// <summary>
+	/// The number of attempts made
+	/// </summary>
+	public int AttemptCount { get; }
+
+	/// <summary>
+	/// The configured <see cref="MerakiClientOptions.MaxAttemptCount"/>
+	/// </summary>
+	public int MaxAttemptCount { get; }
+
+	/// <summary>
+	/// The time spent across every attempt and every wait between them
+	/// </summary>
+	public TimeSpan Elapsed { get; }
+
+	/// <summary>
+	/// The HTTP method
+	/// </summary>
+	public HttpMethod? Method { get; }
+
+	/// <summary>
+	/// The request URI
+	/// </summary>
+	public Uri? RequestUri { get; }
+}

--- a/Meraki.Api/MerakiClientOptions.cs
+++ b/Meraki.Api/MerakiClientOptions.cs
@@ -125,6 +125,21 @@ public class MerakiClientOptions
 	public bool ReadOnly { get; set; }
 
 	/// <summary>
+	/// When true, running out of attempts on a retryable status (429, 502, 503 or 504) throws
+	/// <see cref="RetryExhaustedException"/>, which carries the attempt count, the time spent and the
+	/// final status. Defaults to false, in which case the final response is returned to the caller
+	/// exactly as before, so Refit surfaces an ordinary <see cref="ApiException"/> that is
+	/// indistinguishable from a first-attempt failure with the same status.
+	/// </summary>
+	/// <remarks>
+	/// Opt in where you surface failures to a user or an operator and want to say "throttled for ten
+	/// minutes" rather than "HTTP 429". Leave it off where existing code catches
+	/// <see cref="ApiException"/> and inspects the status code, because <see cref="RetryExhaustedException"/>
+	/// is not an <see cref="ApiException"/> and will not be caught by those handlers.
+	/// </remarks>
+	public bool ThrowOnRetryExhaustion { get; set; }
+
+	/// <summary>
 	/// How to handle missing members
 	/// </summary>
 	public JsonMissingMemberHandling JsonMissingMemberHandling { get; set; } = JsonMissingMemberHandling.Ignore;

--- a/README.md
+++ b/README.md
@@ -207,8 +207,12 @@ var client = new MerakiClient(new MerakiClientOptions
 ```
 
 When attempts run out the client returns the last response, so Refit raises an ordinary `ApiException`
-carrying that status (typically 429). Per-attempt timeouts that run out of attempts throw
-`TimeoutException`.
+carrying that status (typically 429). That response is indistinguishable from a first-attempt 429; if
+you would rather be told "throttled for ten minutes" than "HTTP 429", set
+`ThrowOnRetryExhaustion = true` and the client throws `RetryExhaustedException` instead, carrying the
+attempt count, the time spent and the final status. It is off by default and is not an `ApiException`,
+so existing `catch (ApiException)` handlers will not see it. Per-attempt timeouts that run out of
+attempts throw `TimeoutException`.
 
 ## API Documentation
 


### PR DESCRIPTION
Closes #375

## What

- New `MerakiClientOptions.ThrowOnRetryExhaustion`, **default false**.
- New `Meraki.Api.Exceptions.RetryExhaustedException` with `StatusCode`, `AttemptCount`, `MaxAttemptCount`, `Elapsed`, `Method`, `RequestUri`, and a message such as `Giving up after 3/3 attempts over 0.1s; the last response was 429 TooManyRequests. (GET - https://...)`.
- In `AuthenticatedBackingOffHttpClientHandler`, the existing "Giving up retrying" branch checks the option after logging: false returns the response exactly as before, true disposes it and throws. A `Stopwatch` started once per call supplies `Elapsed`; the existing per-attempt stopwatch is untouched.
- README retries section and CHANGELOG entry.

## Scope, deliberately narrow

Only the 429/502/503/504 exhaustion path changes, and only when opted in. Timeouts still throw `TimeoutException`, transient connection failures still rethrow, non-retryable statuses are still returned on attempt 1, and the "Waiting" log template that DNA.Assure's `RetryObservingLogger` parses is unchanged.

`RetryExhaustedException` is not an `ApiException`. That is intentional, and documented on the option: a consumer who opts in is choosing to handle it separately from status-code-driven handlers.

## Downstream

None of DNA.Assure, DNA.WiserWatts or Cae.Portal sets the option, so none is affected. Cae.Portal's `IsWorthRetrying` and Assure's `ApiHelper` continue to see an `ApiException` with the 429 exactly as today.

## Tests

`Meraki.Api.Test/Client/RetryExhaustionTests.cs` (new, credential-free), 8 tests:

- Default is false; default behaviour returns the last 429 after 3 attempts.
- Opted in: 429 after 3 attempts throws with all six diagnostics populated; 502/503/504 also throw; a 404 and a 200 are still returned on the first attempt.

The four opt-in tests failed against the scaffolded option (no exception thrown) and pass after the change. All 73 unit tests across the handler, options, wiring and workflows suites pass.