### PR TITLE
docs: state that the *AllAsync pagination helpers are all-or-nothing (#355, step one)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Documented that the `*AllAsync` pagination helpers are **all-or-nothing**
+  (issue [#355](https://github.com/panoramicdata/Meraki.Api/issues/355), first step). If any page
+  fails, the exception propagates and the pages already fetched are discarded, so an exception means
+  "no data was returned", never "here is what was fetched so far". Because the Meraki API answers 404
+  for some genuinely empty collections, a 404 on the last of many pages is indistinguishable at the
+  call site from an empty result; callers reconciling a local cache must not treat an exception as
+  "empty". The 27 `*AllAsync` extension methods, the six underlying `GetAll*Async` pager methods and
+  the README now say so. **No behaviour changed.** Attaching the partial results to the exception,
+  so the two cases can be told apart, is a separate decision.
+
 - New opt-in `MerakiClientOptions.ThrowOnRetryExhaustion`
   (issue [#375](https://github.com/panoramicdata/Meraki.Api/issues/375)). When every permitted attempt
   ends in a retryable status (429, 502, 503 or 504), the client has always returned the final response,

--- a/Meraki.Api/Extensions/IApplianceTrafficShapingVpnExclusionsExtensions.cs
+++ b/Meraki.Api/Extensions/IApplianceTrafficShapingVpnExclusionsExtensions.cs
@@ -14,6 +14,14 @@ public static class IApplianceTrafficShapingVpnExclusionsExtensions
 	/// <param name="organizationId">The organization id</param>
 	/// <param name="networkIds">Optional parameter to filter the results by network IDs</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<TrafficShapingVpnExclusionsByNetworkResponse> GetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkAllAsync(
 		this IApplianceTrafficShapingVpnExclusions applianceTrafficShapingVpnExclusions,
 		string organizationId,

--- a/Meraki.Api/Extensions/IApplianceVpnStatsExtensions.cs
+++ b/Meraki.Api/Extensions/IApplianceVpnStatsExtensions.cs
@@ -27,6 +27,14 @@ public static class IApplianceVpnStatsExtensions
 	/// <param name="cancellationToken">A token to monitor for cancellation requests. Defaults to <see cref="CancellationToken.None"/>.</param>
 	/// <returns>A task that represents the asynchronous operation. The task result contains a list of <see cref="VpnStats"/>
 	/// objects representing the VPN statistics for the specified organization.</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<VpnStats>> GetOrganizationApplianceVpnStatsAllAsync(
 		this IApplianceVpnStats applianceVpnStats,
 		string organizationId,

--- a/Meraki.Api/Extensions/IApplianceVpnStatusesExtensions.cs
+++ b/Meraki.Api/Extensions/IApplianceVpnStatusesExtensions.cs
@@ -14,6 +14,14 @@ public static class IApplianceVpnStatusesExtensions
 	/// <param name="organizationId">The organization id.</param>
 	/// <param name="networkIds">A list of Meraki network IDs to filter results to contain only specified networks. E.g.: networkIds[]=N_12345678&amp;networkIds[]=L_3456</param>
 	/// <param name="cancellationToken">Cancellation token to cancel the request.</param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<VpnStatus>> GetOrganizationApplianceVpnStatusesAllAsync(
 		this IApplianceVpnStatuses applianceVpnStatuses,
 		string organizationId,

--- a/Meraki.Api/Extensions/IDeviceSensorCommandsExtensions.cs
+++ b/Meraki.Api/Extensions/IDeviceSensorCommandsExtensions.cs
@@ -16,6 +16,14 @@ public static class IDeviceSensorCommandsExtensions
 	/// <param name="timespan">The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 30 days. The default is 1 day.</param>
 	/// <param name="cancellationToken">Cancellation token.</param>
 	/// <returns>A list of <see cref="SensorCommand"/>.</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<SensorCommand>> GetDeviceSensorCommandsAllAsync(
 		this IDeviceSensorCommands deviceSensorCommands,
 		string serial,

--- a/Meraki.Api/Extensions/ILicensingSubscriptionsExtensions.cs
+++ b/Meraki.Api/Extensions/ILicensingSubscriptionsExtensions.cs
@@ -21,6 +21,14 @@ public static class ILicensingSubscriptionsExtensions
 	/// <param name="startDate">Filter subscriptions by start date, ISO 8601 format. To filter with a range of dates, use 'startDate[]=?' in the request. Accepted options include lt, gt, lte, gte.</param>
 	/// <param name="endDate">Filter subscriptions by end date, ISO 8601 format. To filter with a range of dates, use 'endDate[]=?' in the request. Accepted options include lt, gt, lte, gte.</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<LicensingSubscriptionSubscription>> GetAdministeredLicensingSubscriptionSubscriptionsAllAsync(
 		this ILicensingSubscriptions licensingSubscriptions,
 		List<string>? subscriptionIds,

--- a/Meraki.Api/Extensions/INetworkClientsExtensions.cs
+++ b/Meraki.Api/Extensions/INetworkClientsExtensions.cs
@@ -23,6 +23,14 @@ public static class INetworkClientsExtensions
 	/// <param name="recentDeviceConnections">Filter clients by recent device connections</param>
 	/// <param name="cancellationToken">The cancellation token</param>
 	/// <returns>A list of all clients</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<Client>> GetNetworkClientsAllAsync(
 		this NetworksClientsSection networkClients,
 		string networkId,

--- a/Meraki.Api/Extensions/INetworksVlanProfilesExtensions.cs
+++ b/Meraki.Api/Extensions/INetworksVlanProfilesExtensions.cs
@@ -16,6 +16,14 @@ public static class INetworksVlanProfilesExtensions
 	/// <param name="productTypes">Optional parameter to filter devices by product types.</param>
 	/// <param name="stackIds">Optional parameter to filter devices by Switch Stack ids.</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<VlanProfileDeviceAssignment>> GetNetworkVlanProfilesAssignmentsByDeviceAllAsync(
 		this INetworksVlanProfiles vlanProfiles,
 		string networkId,

--- a/Meraki.Api/Extensions/IOrganizationDevicesExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationDevicesExtensions.cs
@@ -20,6 +20,14 @@ public static class IOrganizationDevicesExtensions
 	/// <param name="statuses">Optional parameter to filter by device statuses.</param>
 	/// <param name="cancellationToken">Cancellation token.</param>
 	/// <returns>A list of <see cref="SensorCommand"/>.</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<OrganizationDevicesAvailabilitiesChangeEvent>> GetOrganizationDevicesAvailabilitiesChangeHistoryAllAsync(
 		this OrganizationsDeviceSection organizationDevices,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationSwitchPortsStatusesExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationSwitchPortsStatusesExtensions.cs
@@ -23,6 +23,14 @@ public static class IOrganizationSwitchPortsStatusesExtensions
 	/// <param name="serials">Optional parameter to filter switchports belonging to switches with one or more serial numbers. All switchports returned belong to serial numbers of switches that are an exact match.</param>
 	/// <param name="configurationUpdatedAfter">Optional parameter to filter results by switches where the configuration has been updated after the given timestamp</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<SwitchPortsStatusesBySwitch>> GetOrganizationSwitchPortsStatusesBySwitchAllAsync(
 		this IOrganizationSwitches organizationSwitchPortsStatusesBySwitch,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsApiRequestsExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsApiRequestsExtensions.cs
@@ -24,6 +24,14 @@ public static class IOrganizationsApiRequestsExtensions
 	/// <param name="version">Filter the results by the API version of the API request</param>
 	/// <param name="operationIds">Filter the results by one or more operation IDs for the API request</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<ApiUsage>> GetOrganizationApiRequestsAllAsync(
 		this IOrganizationsApiRequests organizationsApiRequests,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsAssuranceExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsAssuranceExtensions.cs
@@ -10,6 +10,14 @@ public static class IOrganizationsAssuranceExtensions
 	/// Return all health alerts for an organization
 	/// </summary>
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<OrganizationAssuranceAlert>> GetOrganizationAssuranceAlertsAllAsync(
 		this IOrganizationsAssuranceAlerts organizationAssuranceAlerts,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsConfigurationChangesExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsConfigurationChangesExtensions.cs
@@ -18,6 +18,14 @@ public static class IOrganizationsConfigurationChangesExtensions
 	/// <param name="networkId">Filters on the given network (optional)</param>
 	/// <param name="adminId">Filters on the given Admin (optional)</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<ChangeLogEntry>> GetOrganizationConfigurationChangesAllAsync(
 		this IOrganizationsConfigurationChanges organizationConfigurationChanges,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsExtensions.cs
@@ -10,6 +10,14 @@ public static class IOrganizationsExtensions
 	/// List the organizations that the user has privileges on
 	/// </summary>
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<Organization>> GetOrganizationsAllAsync(
 		this IOrganizations organization,
 		CancellationToken cancellationToken = default)

--- a/Meraki.Api/Extensions/IOrganizationsInventoryDevicesExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsInventoryDevicesExtensions.cs
@@ -23,6 +23,14 @@ public static class IOrganizationsInventoryDevicesExtensions
 	/// <param name="tagsFilterType"></param>
 	/// <param name="productTypes"></param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<InventoryDevice>> GetOrganizationInventoryDevicesAllAsync(
 		this IOrganizationsInventoryDevices organizationInventoryDevices,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsLicensesExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsLicensesExtensions.cs
@@ -16,6 +16,14 @@ public static class IOrganizationsLicensesExtensions
 	/// <param name="networkId">Filter the licenses to those assigned in a particular network (optional)</param>
 	/// <param name="state">Filter the licenses to those in a particular state. Can be one of 'active', 'expired', 'expiring', 'unused', 'unusedActive' or 'recentlyQueued' (optional)</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<OrganizationLicense>> GetOrganizationLicensesAllAsync(
 		this IOrganizationsLicenses organizationsLicenses,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsNetworksExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsNetworksExtensions.cs
@@ -17,6 +17,14 @@ public static class IOrganizationsNetworksExtensions
 	/// <param name="tagsFilterType">An optional parameter of value 'withAnyTags' or 'withAllTags' to indicate whether to return networks which contain ANY or ALL of the included tags. If no type is included, 'withAnyTags' will be selected.</param>
 	/// <param name="productTypes">The product types to filter for</param>
 	/// <param name="cancellationToken">The cancellation token</param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<Network>> GetOrganizationNetworksAllAsync(
 		this IOrganizationsNetworks organizationsNetworks,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsPolicyObjectsExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsPolicyObjectsExtensions.cs
@@ -13,6 +13,14 @@ public static class IOrganizationsPolicyObjectsExtensions
 	/// <param name="organizationsPolicyObjects"></param>
 	/// <param name="organizationId">The organization id</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<OrganizationPolicyObject>> GetOrganizationPolicyObjectsAllAsync(
 		this IOrganizationsPolicyObjects organizationsPolicyObjects,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsPolicyObjectsGroupsExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsPolicyObjectsGroupsExtensions.cs
@@ -13,6 +13,14 @@ public static class IOrganizationsPolicyObjectsGroupsExtensions
 	/// <param name="organizationsPolicyObjectsGroups"></param>
 	/// <param name="organizationId">The organization id</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<OrganizationPolicyObjectsGroup>> GetOrganizationPolicyObjectsGroupsAllAsync(
 		this IOrganizationsPolicyObjectsGroups organizationsPolicyObjectsGroups,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsSecureConnectSitesExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsSecureConnectSitesExtensions.cs
@@ -14,6 +14,14 @@ public static class IOrganizationsSecureConnectSitesExtensions
 	/// <param name="enrolledState">Filter results by sites that have already been enrolled or can be enrolled. Acceptable values are 'enrolled' or 'enrollable'</param>
 	/// <param name="pageSize"></param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<SecureConnectSite>> GetOrganizationSecureConnectSitesAllAsync(
 		this IOrganizationsSecureConnectSites organizationsSecureConnectSites,
 		string organizationId,

--- a/Meraki.Api/Extensions/IOrganizationsWirelessMqttExtensions.cs
+++ b/Meraki.Api/Extensions/IOrganizationsWirelessMqttExtensions.cs
@@ -13,6 +13,14 @@ public static class IOrganizationsWirelessMqttExtensions
 	/// <param name="organizationId">The organization id</param>
 	/// <param name="networkIds">Optional parameter to filter mqtt settings by network ID</param>
 	/// <param name="cancellationToken">The cancellation token</param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<OrganizationWirelessMqttSettings>> GetOrganizationWirelessMqttSettingsAllAsync(
 		this IOrganizationsWirelessMqtt organizationsWirelessMqtt,
 		string organizationId,

--- a/Meraki.Api/Extensions/ISwitchDhcpServerPolicyArpInspectionTrustedServersExtenions.cs
+++ b/Meraki.Api/Extensions/ISwitchDhcpServerPolicyArpInspectionTrustedServersExtenions.cs
@@ -12,6 +12,14 @@ public static class ISwitchDhcpServerPolicyArpInspectionTrustedServersExtenions
 	/// <param name="switchDhcpServerPolicyArpInspectionTrustedServer"></param>
 	/// <param name="networkId">The network id</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<TrustedServer>> GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersAllAsync(
 		this ISwitchDhcpServerPolicyArpInspectionTrustedServers switchDhcpServerPolicyArpInspectionTrustedServer,
 		string networkId,

--- a/Meraki.Api/Extensions/ISwitchPortsBySwitchExtension.cs
+++ b/Meraki.Api/Extensions/ISwitchPortsBySwitchExtension.cs
@@ -19,6 +19,14 @@ public static class ISwitchPortsBySwitchExtensions
 	/// <param name="serials">Optional parameter to filter switchports belonging to switches with one or more serial numbers. All switchports returned belong to serial numbers of switches that are an exact match.</param>
 	/// <param name="macs">Optional parameter to filter switchports by one or more MAC addresses belonging to devices. All switchports returned belong to MAC addresses of switches that are an exact match.</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<SwitchPortsBySwitch>> GetOrganizationSwitchPortsBySwitchAllAsync(
 		this IOrganizationSwitches switchPortsBySwitch,
 		string organizationId,

--- a/Meraki.Api/Extensions/IWirelessDevicesEthernetStatusesExtentions.cs
+++ b/Meraki.Api/Extensions/IWirelessDevicesEthernetStatusesExtentions.cs
@@ -12,6 +12,14 @@ public static class IWirelessDevicesEthernetStatusesExtentions
 	/// <param name="wirelessDeviceEthernetStatuses"></param>
 	/// <param name="organizationId">The organization id</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<WirelessDeviceEthernetStatus>> GetOrganizationWirelessDevicesEthernetStatusesAllAsync(
 		this IWirelessDeviceEthernetStatuses wirelessDeviceEthernetStatuses,
 		string organizationId,

--- a/Meraki.Api/Extensions/IWirelessRfProfilesExtentions.cs
+++ b/Meraki.Api/Extensions/IWirelessRfProfilesExtentions.cs
@@ -21,6 +21,14 @@ public static class IWirelessRfProfilesExtensions
 	/// <param name="serials">Optional parameter to filter RF profiles by one or more device serial numbers. All returned devices will have a serial number that is an exact match.</param>
 	/// <param name="models">Optional parameter to filter RF profiles by one or more device models. All returned devices will have a model that is an exact match.</param>
 	/// <param name="cancellationToken">The cancellation token.</param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<RfProfilesByDevice>> GetOrganizationWirelessRfProfilesAssignmentsByDeviceAllAsync(
 		this IWirelessRfProfiles wirelessRfProfilesAssignments,
 		string organizationId,

--- a/Meraki.Api/Extensions/OrganizationsDeviceSectionExtensions.cs
+++ b/Meraki.Api/Extensions/OrganizationsDeviceSectionExtensions.cs
@@ -20,6 +20,14 @@ public static class OrganizationsDeviceSectionExtensions
 	/// <param name="tags">An optional parameter to filter devices by tags. The filtering is case-sensitive. If tags are included, 'tagsFilterType' should also be included (see below).</param>
 	/// <param name="tagsFilterType">An optional parameter of value 'withAnyTags' or 'withAllTags' to indicate whether to return devices which contain ANY or ALL of the included tags. If no type is included, 'withAnyTags' will be selected.</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<OrganizationDeviceStatus>> GetOrganizationDevicesStatusesAllAsync(
 		this OrganizationsDeviceSection organizationDevices,
 		string organizationId,
@@ -62,6 +70,14 @@ public static class OrganizationsDeviceSectionExtensions
 	/// <param name="tags">An optional parameter to filter devices by tags. The filtering is case-sensitive. If tags are included, 'tagsFilterType' should also be included (see below).</param>
 	/// <param name="tagsFilterType">An optional parameter of value 'withAnyTags' or 'withAllTags' to indicate whether to return devices which contain ANY or ALL of the included tags. If no type is included, 'withAnyTags' will be selected.</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<DeviceProvisioningStatus>> GetOrganizationDevicesProvisioningStatusesAllAsync(
 		this OrganizationsDeviceSection organizationDevices,
 		string organizationId,
@@ -110,6 +126,14 @@ public static class OrganizationsDeviceSectionExtensions
 	/// <param name="sensorAlertProfileIds">Optional parameter to filter devices by the alert profiles that are bound to them. Only applies to sensor devices.</param>
 	/// <param name="models">Optional parameter to filter devices by one or more models. All returned devices will have a model that is an exact match</param>
 	/// <param name="cancellationToken"></param>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
 	public static Task<List<OrganizationDevice>> GetOrganizationDevicesAllAsync(
 		this OrganizationsDeviceSection organizationDevices,
 		string organizationId,

--- a/Meraki.Api/MerakiClientPager.cs
+++ b/Meraki.Api/MerakiClientPager.cs
@@ -83,6 +83,15 @@ public partial class MerakiClient
 	/// <param name="perPage">The number of items per page</param>
 	/// <param name="cancellationToken">The cancellation token</param>
 	/// <returns>A list of all items</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
+	/// <exception cref="PaginationException">A page advertised a next page that could not be followed.</exception>
 	public async Task<List<T>> GetAllAsync<T>(
 		Func<int, string?, string?, CancellationToken, Task<List<T>>> pageFactoryAsync,
 		int perPage,
@@ -114,6 +123,15 @@ public partial class MerakiClient
 	/// <param name="pageFactoryAsync">The function to call for each page of results</param>
 	/// <param name="cancellationToken">The cancellation token</param>
 	/// <returns>A list of all items</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
+	/// <exception cref="PaginationException">A page advertised a next page that could not be followed.</exception>
 	public async Task<List<T>> GetAllAsync<T>(
 		Func<string?, string?, CancellationToken, Task<List<T>>> pageFactoryAsync,
 		CancellationToken cancellationToken)
@@ -144,6 +162,15 @@ public partial class MerakiClient
 	/// <param name="pageFactoryAsync">The function to call for each page of results</param>
 	/// <param name="cancellationToken">The cancellation token</param>
 	/// <returns>A list of all items</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
+	/// <exception cref="PaginationException">A page advertised a next page that could not be followed.</exception>
 	public static async Task<List<T>> GetAllAsync<T>(
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		Func<string?, string?, CancellationToken, Task<ApiResponse<List<T>>>> pageFactoryAsync,
@@ -179,6 +206,15 @@ public partial class MerakiClient
 	/// <param name="timeSpan">The timespan duration</param>
 	/// <param name="cancellationToken">The cancellation token</param>
 	/// <returns>A list of all items</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
+	/// <exception cref="PaginationException">A page advertised a next page that could not be followed.</exception>
 	public static async Task<List<T>> GetAllAsync<T>(
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		Func<string?, string?, string?, string?, double?, CancellationToken, Task<ApiResponse<List<T>>>> pageFactoryAsync,
@@ -215,6 +251,15 @@ public partial class MerakiClient
 	/// <param name="perPage">The number of items per page</param>
 	/// <param name="cancellationToken">The cancellation token</param>
 	/// <returns>A list of all items</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
+	/// <exception cref="PaginationException">A page advertised a next page that could not be followed.</exception>
 	public static async Task<List<T>> GetAllAsync<T>(
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		Func<int?, string?, string?, CancellationToken, Task<ApiResponse<List<T>>>> pageFactoryAsync,
@@ -250,6 +295,15 @@ public partial class MerakiClient
 	/// <param name="propertyFunction">A function that extracts a list of models from the API response.</param>
 	/// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
 	/// <returns>A task that represents the asynchronous operation. The task result contains a list of all models retrieved from all pages.</returns>
+	/// <remarks>
+	/// Fetches every page before returning and is <b>all-or-nothing</b>: if any page fails, the
+	/// exception propagates and the pages already fetched are discarded. An exception therefore means
+	/// "no data was returned", never "here is what was fetched so far". In particular, a 404 from a
+	/// genuinely empty collection and a 404 on the last of many pages reach the caller identically, so
+	/// do not treat an exception as an empty result; retry or fail instead. See
+	/// <see href="https://github.com/panoramicdata/Meraki.Api/issues/355">issue 355</see>.
+	/// </remarks>
+	/// <exception cref="PaginationException">A page advertised a next page that could not be followed.</exception>
 	public static async Task<List<TModel>> GetAllFromResponsePropertyAsync<TResponse, TModel>(
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		Func<string?, string?, CancellationToken, Task<ApiResponse<TResponse>>> pageFactoryAsync,

--- a/README.md
+++ b/README.md
@@ -214,6 +214,26 @@ attempt count, the time spent and the final status. It is off by default and is 
 so existing `catch (ApiException)` handlers will not see it. Per-attempt timeouts that run out of
 attempts throw `TimeoutException`.
 
+## Pagination
+
+Endpoints that return large collections are paginated by the Meraki API using `startingAfter` /
+`endingBefore` cursors and a `Link: rel=next` header. Each such endpoint has a matching `*AllAsync`
+extension method (for example `GetOrganizationNetworksAllAsync`) that follows the links and returns
+the whole collection as one list.
+
+These helpers are **all-or-nothing**. If any page fails, the exception propagates and every page
+already fetched is discarded, so an exception means "no data was returned", never "here is what was
+fetched so far". Two consequences for calling code:
+
+- A 404 from a genuinely empty collection and a 404 on the last of many pages reach the caller as the
+  same `ApiException`. Do not treat an exception from an `*AllAsync` call as an empty result. Code
+  that reconciles a local cache against the returned list should retry or abort on exception rather
+  than delete everything.
+- If the API advertises a next page the client cannot follow, the helpers throw `PaginationException`
+  rather than return a silently truncated list.
+
+Per-page methods (the same name without `All`) return one page and leave cursor handling to you.
+
 ## API Documentation
 
 The Meraki API documentation can be found here:


### PR DESCRIPTION
Refs #355 (first of two steps; leaves the issue open)

## What

Documentation only. **No behaviour changed.**

- `<remarks>` on all 27 `*AllAsync` extension methods and the six underlying `GetAll*Async` pager methods: the helpers are all-or-nothing, an exception means no data was returned, and a 404 from an empty collection is indistinguishable from a 404 on the last page, so callers must not treat an exception as an empty result. The pager methods also gain an `<exception cref="PaginationException">` tag from #356.
- New README "Pagination" section with the same guidance and the cache-reconciliation warning from the issue.
- CHANGELOG entry.

## Why this first

The issue's third suggestion, and the only one with no compatibility surface. It makes the contract explicit today, so consumers such as DNA.Assure's `ApiHelper` (which catches 404 and continues with partial backup data) can be reviewed against a documented rule rather than an inferred one.

## What is left for step two

Attaching the partial results to the exception (`MerakiPagedApiException : ApiException` carrying `PartialResults` and `PagesFetched`, preserving `StatusCode` and `Content`) so the two 404 cases can be told apart. That is a separate decision and a separate PR.

## Verification

`dotnet build Meraki.Api` succeeds with no XML documentation warnings. The diff is pure additions: BOM and line endings are preserved on every touched file.