### PR TITLE
fix: wire the 82 Refit clients and 4 sub-sections the constructor left null (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Every section and Refit client on `MerakiClient` is now wired** (issue
+  [#357](https://github.com/panoramicdata/Meraki.Api/issues/357)). The constructor is a hand-maintained
+  mirror of a 134-class section tree and had drifted: 82 Refit interface properties and 4 sub-section
+  objects (`Devices.Appliance`, `Devices.Wireless`, `Networks.Switch`,
+  `Organizations.Certificates.RadSec`) were left null, so roughly a fifth of the client surface threw
+  `NullReferenceException` on first use. All 86 are now assigned. Two credential-free tests prevent
+  recurrence: `MerakiClientSectionCensusTests.Constructor_LeavesNoSectionOrRefitClientNull` walks the
+  whole tree by reflection and fails on any null, and `EveryRefitInterface_CanBeConstructed` builds
+  every Refit interface in the assembly. The second test found one more defect: `Refit.Reflection` was
+  never referenced, so the RF006 fallback the project relies on did not exist at runtime and
+  `IOrganizationsCameraDetections` could not be constructed at all. It is now referenced. Constructing
+  a `MerakiClient` builds about 90 more Refit proxies than before, which adds a few tens of
+  milliseconds per instance; code that constructs a client per call may want to reuse one.
+
 - Documented that the `*AllAsync` pagination helpers are **all-or-nothing**
   (issue [#355](https://github.com/panoramicdata/Meraki.Api/issues/355), first step). If any page
   fails, the exception propagates and the pages already fetched are discarded, so an exception means

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="PanoramicData.SheetMagic" Version="3.1.140" />
     <PackageVersion Include="Refit" Version="15.2.0" />
     <PackageVersion Include="Refit.Newtonsoft.Json" Version="15.2.0" />
+    <PackageVersion Include="Refit.Reflection" Version="15.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />

--- a/Meraki.Api.Test/MerakiClientSectionCensusTests.cs
+++ b/Meraki.Api.Test/MerakiClientSectionCensusTests.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+
+namespace Meraki.Api.Test;
+
+/// <summary>
+/// Walks the whole section tree of a freshly constructed <see cref="MerakiClient"/> and fails if
+/// any section or Refit client is left null
+/// (<see href="https://github.com/panoramicdata/Meraki.Api/issues/357">issue 357</see>).
+/// The constructor is a hand-maintained mirror of the section tree, and a missing entry compiles
+/// cleanly because every property is declared <c>= null!</c>; this is the check that catches the
+/// drift. No credentials or network are needed.
+/// </summary>
+public class MerakiClientSectionCensusTests
+{
+	private const string SectionsNamespace = "Meraki.Api.Sections";
+	private const string InterfacesNamespace = "Meraki.Api.Interfaces";
+
+	private static MerakiClient CreateClient()
+		=> new(new MerakiClientOptions
+		{
+			ApiKey = "0000000000000000000000000000000000000000",
+			UserAgent = "Meraki.Api.Test/1.0"
+		});
+
+	[Fact]
+	public void Constructor_LeavesNoSectionOrRefitClientNull()
+	{
+		using var client = CreateClient();
+
+		var nulls = new List<string>();
+		var visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+		Walk(client, "client", nulls, visited);
+
+		_ = nulls.Should().BeEmpty("every section and Refit client should be assigned by the constructor, but these were null:\n  {0}", string.Join("\n  ", nulls));
+	}
+
+	[Fact]
+	public void EveryRefitInterface_CanBeConstructed()
+	{
+		// The single-argument RestService.For<T>(HttpClient) overload, chosen deliberately: the
+		// (HttpClient, IRequestBuilder<T>) overload with a null builder constructs anything.
+		var forMethod = typeof(RestService)
+			.GetMethods(BindingFlags.Public | BindingFlags.Static)
+			.Single(m => m.Name == nameof(RestService.For)
+				&& m.IsGenericMethodDefinition
+				&& m.GetParameters() is [{ ParameterType: var p }] && p == typeof(HttpClient));
+		using var httpClient = new HttpClient { BaseAddress = new Uri("https://api.meraki.com/api/v1") };
+
+		var failures = new List<string>();
+		foreach (var type in RefitInterfaces())
+		{
+			try
+			{
+				_ = forMethod.MakeGenericMethod(type).Invoke(null, [httpClient]);
+			}
+			catch (TargetInvocationException ex)
+			{
+				failures.Add($"{type.Name}: {ex.InnerException?.Message}");
+			}
+		}
+
+		_ = failures.Should().BeEmpty("every Refit interface should build, but these did not:\n  {0}", string.Join("\n  ", failures));
+	}
+
+	/// <summary>
+	/// Every interface under Meraki.Api.Interfaces that carries at least one Refit HTTP method
+	/// attribute. Interfaces without one (for example IRateLimiter) are not Refit clients.
+	/// </summary>
+	private static IEnumerable<Type> RefitInterfaces()
+		=> typeof(MerakiClient).Assembly
+			.GetTypes()
+			.Where(t => t.IsInterface
+				&& t.Namespace?.StartsWith(InterfacesNamespace, StringComparison.Ordinal) == true
+				&& IsRefitClient(t));
+
+	private static bool IsRefitClient(Type type)
+		=> type.GetMethods().Any(m => m.GetCustomAttributes(true).OfType<HttpMethodAttribute>().Any());
+
+	private static void Walk(object node, string path, List<string> nulls, HashSet<object> visited)
+	{
+		if (!visited.Add(node))
+		{
+			return;
+		}
+
+		var properties = node
+			.GetType()
+			.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+			.Where(p => p.GetIndexParameters().Length == 0);
+
+		foreach (var property in properties)
+		{
+			var type = property.PropertyType;
+			var isSection = type.IsClass && type.Namespace?.StartsWith(SectionsNamespace, StringComparison.Ordinal) == true;
+			var isRefitClient = type.IsInterface
+				&& type.Namespace?.StartsWith(InterfacesNamespace, StringComparison.Ordinal) == true
+				&& IsRefitClient(type);
+			if (!isSection && !isRefitClient)
+			{
+				continue;
+			}
+
+			var value = property.GetValue(node);
+			var childPath = $"{path}.{property.Name}";
+			if (value is null)
+			{
+				nulls.Add($"{childPath} ({type.Name})");
+			}
+			else if (isSection)
+			{
+				Walk(value, childPath, nulls, visited);
+			}
+		}
+	}
+}

--- a/Meraki.Api/Meraki.Api.csproj
+++ b/Meraki.Api/Meraki.Api.csproj
@@ -6,7 +6,11 @@
 		     cannot build without reflection, so they fall back to the reflection request builder.
 		     That is the supported path here: MerakiClient creates every client with
 		     RestService.For<T>(), which the diagnostic explicitly permits, and this library is not
-		     trimmed or AOT-published. Revisit if it ever moves to AddRefitGeneratedClient. -->
+		     trimmed or AOT-published. The fallback only exists when Refit.Reflection is referenced
+		     (below); without it RestService.For<T>() throws for the whole interface at runtime,
+		     which is what left IOrganizationsCameraDetections unconstructable (issue #357).
+		     MerakiClientSectionCensusTests.EveryRefitInterface_CanBeConstructed guards this.
+		     Revisit if it ever moves to AddRefitGeneratedClient. -->
     <NoWarn>$(NoWarn);RF006</NoWarn>
     <!-- CS0618: Refit 15 generates interface stubs that reference [Obsolete] members of this
 		     API - ProductType.Environmental and ProductType.VmConcentrator, which Meraki retired
@@ -77,6 +81,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Refit" />
     <PackageReference Include="Refit.Newtonsoft.Json" />
+    <PackageReference Include="Refit.Reflection" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol.Core" />

--- a/Meraki.Api/MerakiClient.GeneralSections.cs
+++ b/Meraki.Api/MerakiClient.GeneralSections.cs
@@ -17,12 +17,41 @@ public partial class MerakiClient
 		=> new()
 		{
 			Devices = RefitFor(Devices.Devices),
+			Appliance = BuildDevicesApplianceSection(),
 			CellularSims = RefitFor(Devices.CellularSims),
 			Clients = RefitFor(Devices.Clients),
 			LldpCdp = RefitFor(Devices.LldpCdp),
 			LossAndLatencyHistory = RefitFor(Devices.LossAndLatencyHistory),
 			ManagementInterface = RefitFor(Devices.ManagementInterface),
 			SensorCommands = RefitFor(Devices.SensorCommands),
+			Wireless = BuildDevicesWirelessSection(),
+		};
+
+	private DevicesApplianceSection BuildDevicesApplianceSection()
+		=> new()
+		{
+			Prefixes = RefitFor(Devices.Appliance.Prefixes)
+		};
+
+	private DevicesWirelessSection BuildDevicesWirelessSection()
+		=> new()
+		{
+			DevicesWireless = RefitFor(Devices.Wireless.DevicesWireless),
+			AlternateManagementInterface = RefitFor(Devices.Wireless.AlternateManagementInterface),
+			Radio = BuildDevicesWirelessRadioSection(),
+			Zigbee = BuildDevicesWirelessZigbeeSection()
+		};
+
+	private DevicesWirelessRadioSection BuildDevicesWirelessRadioSection()
+		=> new()
+		{
+			Afc = RefitFor(Devices.Wireless.Radio.Afc)
+		};
+
+	private DevicesWirelessZigbeeSection BuildDevicesWirelessZigbeeSection()
+		=> new()
+		{
+			Enrollments = RefitFor(Devices.Wireless.Zigbee.Enrollments)
 		};
 
 	private OrganizationsSection BuildOrganizationsSection()
@@ -36,9 +65,14 @@ public partial class MerakiClient
 			ApiRequests = RefitFor(Organizations.ApiRequests),
 			Appliance = BuildOrganizationsApplianceSection(),
 			ApplianceSecurityEvents = RefitFor(Organizations.ApplianceSecurityEvents),
+			Assurance = RefitFor(Organizations.Assurance),
 			AssuranceAlerts = RefitFor(Organizations.AssuranceAlerts),
 			BrandingPolicies = BuildOrganizationsBrandingPoliciesSection(),
+			Camera = BuildOrganizationsCameraSection(),
+			CampusGateway = BuildOrganizationsCampusGatewaySection(),
+			Certificates = BuildOrganizationsCertificatesSection(),
 			Clients = BuildOrganizationsClientsSection(),
+			Cloud = BuildOrganizationsCloudSection(),
 			ConfigurationChanges = RefitFor(Organizations.ConfigurationChanges),
 			ConfigTemplates = BuildOrganizationsConfigTemplatesSection(),
 			Devices = BuildOrganizationsDevicesSection(),
@@ -46,24 +80,38 @@ public partial class MerakiClient
 			{
 				Features = RefitFor(Organizations.EarlyAccess.Features)
 			},
+			Extensions = BuildOrganizationsExtensionsSection(),
+			Firmware = RefitFor(Organizations.Firmware),
+			Insight = BuildOrganizationsInsightSection(),
+			Integrations = BuildOrganizationsIntegrationsSection(),
+			Inventory = BuildOrganizationsInventorySection(),
 			InventoryDevices = RefitFor(Organizations.InventoryDevices),
 			Licenses = RefitFor(Organizations.Licenses),
 			LoginSecurity = RefitFor(Organizations.LoginSecurity),
+			Nac = BuildOrganizationsNacSection(),
 			Networks = RefitFor(Organizations.Networks),
+			NewtworkDevices = RefitFor(Organizations.NewtworkDevices),
 			OpenapiSpec = RefitFor(Organizations.OpenapiSpec),
+			Policies = BuildOrganizationsPoliciesSection(),
 			PolicyObjects = RefitFor(Organizations.PolicyObjects),
 			PolicyObjectGroups = RefitFor(Organizations.PolicyObjectGroups),
 			Saml = BuildOrganizationsSamlSection(),
 			SamlRoles = RefitFor(Organizations.SamlRoles),
+			Sase = BuildOrganizationsSaseSection(),
 			SecureConnect = BuildOrganizationsSecureConnectSection(),
+			Sensor = RefitFor(Organizations.Sensor),
+			Sm = BuildOrganizationsSmSection(),
 			Snmp = RefitFor(Organizations.Snmp),
+			Spaces = BuildOrganizationsSpacesSection(),
 			Splash = RefitFor(Organizations.Splash),
 			Summary = BuildOrganizationsSummarySection(),
+			Support = RefitFor(Organizations.Support),
 			Switches = RefitFor(Organizations.Switches),
 			SwitchPortsOverview = RefitFor(Organizations.SwitchPortsOverview),
 			Uplinks = RefitFor(Organizations.Uplinks),
 			Webhooks = BuildOrganizationsWebhooksSection(),
-			Wireless = BuildOrganizationsWirelessSection()
+			Wireless = BuildOrganizationsWirelessSection(),
+			WirelessController = BuildOrganizationsWirelessControllerSection()
 		};
 
 	private NetworksSection BuildNetworksSection()
@@ -72,9 +120,15 @@ public partial class MerakiClient
 			Networks = RefitFor(Networks.Networks),
 			Alerts = new()
 			{
+				NetworksAlerts = RefitFor(Networks.Alerts.NetworksAlerts),
 				Settings = RefitFor(Networks.Alerts.Settings)
 			},
+			Appliance = new()
+			{
+				Umbrella = RefitFor(Networks.Appliance.Umbrella)
+			},
 			BluetoothClients = RefitFor(Networks.BluetoothClients),
+			CampusGateway = RefitFor(Networks.CampusGateway),
 			Clients = BuildNetworksClientsSection(),
 			Devices = RefitFor(Networks.Devices),
 			Events = BuildNetworksEventsSection(),
@@ -82,19 +136,56 @@ public partial class MerakiClient
 			Floorplans = RefitFor(Networks.Floorplans),
 			GroupPolicies = RefitFor(Networks.GroupPolicies),
 			Health = BuildNetworksHealthSection(),
+			LocationScanning = RefitFor(Networks.LocationScanning),
 			MerakiAuthUsers = RefitFor(Networks.MerakiAuthUsers),
 			MqttBrokers = RefitFor(Networks.MqttBrokers),
 			Netflow = RefitFor(Networks.Netflow),
 			Pii = BuildNetworksPiiSection(),
+			Policies = RefitFor(Networks.Policies),
+			Sensor = BuildNetworksSensorSection(),
+			Sm = RefitFor(Networks.Sm),
 			Traffic = RefitFor(Networks.Traffic),
 			Settings = RefitFor(Networks.Settings),
 			Snmp = RefitFor(Networks.Snmp),
 			SplashLoginAttempts = RefitFor(Networks.SplashLoginAttempts),
+			Switch = BuildNetworksSwitchSection(),
 			SyslogServers = RefitFor(Networks.SyslogServers),
 			TrafficAnalysis = RefitFor(Networks.TrafficAnalysis),
 			VlanProfiles = RefitFor(Networks.VlanProfiles),
 			TrafficShaping = BuildNetworksTrafficShapingSection(),
-			Webhooks = BuildNetworksWebhooksSection()
+			Webhooks = BuildNetworksWebhooksSection(),
+			Wireless = BuildNetworksWirelessSection()
+		};
+
+	private NetworksSwitchSection BuildNetworksSwitchSection()
+		=> new()
+		{
+			Ports = RefitFor(Networks.Switch.Ports),
+			Dhcp = RefitFor(Networks.Switch.Dhcp),
+			DhcpServerPolicy = RefitFor(Networks.Switch.DhcpServerPolicy),
+			Stacks = RefitFor(Networks.Switch.Stacks)
+		};
+
+	private NetworksSensorSection BuildNetworksSensorSection()
+		=> new()
+		{
+			Alerts = new()
+			{
+				Current = RefitFor(Networks.Sensor.Alerts.Current),
+				Overview = RefitFor(Networks.Sensor.Alerts.Overview)
+			},
+			Schedules = RefitFor(Networks.Sensor.Schedules)
+		};
+
+	private NetworksWirelessSection BuildNetworksWirelessSection()
+		=> new()
+		{
+			Clients = RefitFor(Networks.Wireless.Clients),
+			Devices = RefitFor(Networks.Wireless.Devices),
+			Location = RefitFor(Networks.Wireless.Location),
+			OpportunisticPcap = RefitFor(Networks.Wireless.OpportunisticPcap),
+			Radio = RefitFor(Networks.Wireless.Radio),
+			Zigbee = RefitFor(Networks.Wireless.Zigbee)
 		};
 	private OrganizationsApiSection BuildOrganizationsApiSection()
 		=> new()
@@ -180,11 +271,32 @@ public partial class MerakiClient
 	private OrganizationsWirelessSection BuildOrganizationsWirelessSection()
 		=> new()
 		{
+			LocationScanning = RefitFor(Organizations.Wireless.LocationScanning),
+			Zigbee = RefitFor(Organizations.Wireless.Zigbee),
+			Clients = RefitFor(Organizations.Wireless.Clients),
+			Certificates = new()
+			{
+				OpenRoaming = RefitFor(Organizations.Wireless.Certificates.OpenRoaming)
+			},
 			Devices = new()
 			{
 				ChannelUtilization = RefitFor(Organizations.Wireless.Devices.ChannelUtilization),
 				Latency = RefitFor(Organizations.Wireless.Devices.Latency),
-				PacketLoss = RefitFor(Organizations.Wireless.Devices.PacketLoss)
+				PacketLoss = RefitFor(Organizations.Wireless.Devices.PacketLoss),
+				Radio = RefitFor(Organizations.Wireless.Devices.Radio),
+				Radsec = new()
+				{
+					Certificates = RefitFor(Organizations.Wireless.Devices.Radsec.Certificates)
+				}
+			},
+			OpportunisticPcap = RefitFor(Organizations.Wireless.OpportunisticPcap),
+			Mqtt = RefitFor(Organizations.Wireless.Mqtt),
+			Ssids = new()
+			{
+				Firewall = new()
+				{
+					Isolation = RefitFor(Organizations.Wireless.Ssids.Firewall.Isolation)
+				}
 			}
 		};
 
@@ -202,9 +314,36 @@ public partial class MerakiClient
 	private OrganizationsApplianceSection BuildOrganizationsApplianceSection()
 		=> new()
 		{
+			Dns = BuildOrganizationsApplianceDnsSection(),
+			Sdwan = RefitFor(Organizations.Appliance.Sdwan),
 			Uplinks = new()
 			{
 				Usage = RefitFor(Organizations.Appliance.Uplinks.Usage)
+			},
+			Vlans = RefitFor(Organizations.Appliance.Vlans),
+			Vpn = BuildOrganizationsVpnSection()
+		};
+
+	private OrganizationsApplianceDnsSection BuildOrganizationsApplianceDnsSection()
+		=> new()
+		{
+			Local = new()
+			{
+				Profiles = RefitFor(Organizations.Appliance.Dns.Local.Profiles),
+				Records = RefitFor(Organizations.Appliance.Dns.Local.Records)
+			},
+			Split = new()
+			{
+				Profiles = RefitFor(Organizations.Appliance.Dns.Split.Profiles)
+			}
+		};
+
+	private OrganizationsVpnSection BuildOrganizationsVpnSection()
+		=> new()
+		{
+			SiteToSite = new()
+			{
+				Ipsec = RefitFor(Organizations.Appliance.Vpn.SiteToSite.Ipsec)
 			}
 		};
 
@@ -220,9 +359,11 @@ public partial class MerakiClient
 		=> new()
 		{
 			AlertTypes = RefitFor(Organizations.Webhooks.AlertTypes),
+			Callbacks = RefitFor(Organizations.Webhooks.Callbacks),
 			Logs = RefitFor(Organizations.Webhooks.Logs),
 			PayloadTemplates = RefitFor(Organizations.Webhooks.PayloadTemplates),
-			HttpServers = RefitFor(Organizations.Webhooks.HttpServers)
+			HttpServers = RefitFor(Organizations.Webhooks.HttpServers),
+			WebhookTests = RefitFor(Organizations.Webhooks.WebhookTests)
 		};
 
 	private NetworksPiiSection BuildNetworksPiiSection()
@@ -288,6 +429,156 @@ public partial class MerakiClient
 		{
 			ApplicationCategories = RefitFor(Networks.TrafficShaping.ApplicationCategories),
 			DscpTaggingOptions = RefitFor(Networks.TrafficShaping.DscpTaggingOptions)
+		};
+
+	private OrganizationsCameraSection BuildOrganizationsCameraSection()
+		=> new()
+		{
+			Permissions = RefitFor(Organizations.Camera.Permissions),
+			Detections = RefitFor(Organizations.Camera.Detections)
+		};
+
+	private OrganizationsCampusGateway BuildOrganizationsCampusGatewaySection()
+		=> new()
+		{
+			Clusters = RefitFor(Organizations.CampusGateway.Clusters),
+			Devices = new()
+			{
+				Uplinks = new()
+				{
+					LocalOverrides = RefitFor(Organizations.CampusGateway.Devices.Uplinks.LocalOverrides)
+				}
+			}
+		};
+
+	private OrganizationsCertificatesSection BuildOrganizationsCertificatesSection()
+		=> new()
+		{
+			Certificates = RefitFor(Organizations.Certificates.Certificates),
+			RadSec = BuildOrganizationsCertificatesRadSecSection()
+		};
+
+	private OrganizationsCertificatesRadSecSection BuildOrganizationsCertificatesRadSecSection()
+		=> new()
+		{
+			DeviceCertificateAuthorities = RefitFor(Organizations.Certificates.RadSec.DeviceCertificateAuthorities)
+		};
+
+	private OrganizationsCloudSection BuildOrganizationsCloudSection()
+		=> new()
+		{
+			Connectivity = RefitFor(Organizations.Cloud.Connectivity)
+		};
+
+	private OrganizationsExtensionsSection BuildOrganizationsExtensionsSection()
+		=> new()
+		{
+			SdwanManager = new()
+			{
+				Interconnects = RefitFor(Organizations.Extensions.SdwanManager.Interconnects)
+			},
+			ThousandEyes = RefitFor(Organizations.Extensions.ThousandEyes)
+		};
+
+	private OrganizationsInsightSection BuildOrganizationsInsightSection()
+		=> new()
+		{
+			Insight = RefitFor(Organizations.Insight.Insight),
+			Applications = RefitFor(Organizations.Insight.Applications),
+			WebApps = RefitFor(Organizations.Insight.WebApps)
+		};
+
+	private OrganizationsIntegrationsSection BuildOrganizationsIntegrationsSection()
+		=> new()
+		{
+			Xdr = RefitFor(Organizations.Integrations.Xdr)
+		};
+
+	private OrganizationsInventorySection BuildOrganizationsInventorySection()
+		=> new()
+		{
+			Onboarding = new()
+			{
+				CloudMonitoring = RefitFor(Organizations.Inventory.Onboarding.CloudMonitoring)
+			},
+			Orders = RefitFor(Organizations.Inventory.Orders)
+		};
+
+	private OrganizationsNacSection BuildOrganizationsNacSection()
+		=> new()
+		{
+			Authorization = RefitFor(Organizations.Nac.Authorization),
+			Sessions = RefitFor(Organizations.Nac.Sessions)
+		};
+
+	private OrganizationsPoliciesSection BuildOrganizationsPoliciesSection()
+		=> new()
+		{
+			Assignments = RefitFor(Organizations.Policies.Assignments)
+		};
+
+	private OrganizationsSaseSection BuildOrganizationsSaseSection()
+		=> new()
+		{
+			Connectivity = RefitFor(Organizations.Sase.Connectivity)
+		};
+
+	private OrganizationsSmSection BuildOrganizationsSmSection()
+		=> new()
+		{
+			Admins = RefitFor(Organizations.Sm.Admins),
+			Apple = RefitFor(Organizations.Sm.Apple),
+			BulkEnrollment = RefitFor(Organizations.Sm.BulkEnrollment),
+			Sentry = RefitFor(Organizations.Sm.Sentry)
+		};
+
+	private OrganizationsSpacesSection BuildOrganizationsSpacesSection()
+		=> new()
+		{
+			Integration = RefitFor(Organizations.Spaces.Integration)
+		};
+
+	private OrganizationsWirelessControllerSection BuildOrganizationsWirelessControllerSection()
+		=> new()
+		{
+			WirelessController = RefitFor(Organizations.WirelessController.WirelessController),
+			Connections = RefitFor(Organizations.WirelessController.Connections),
+			Clients = BuildOrganizationsWirelessControllerClientsSection(),
+			Devices = BuildOrganizationsWirelessControllerDevicesSection(),
+			Availabilities = RefitFor(Organizations.WirelessController.Availabilities),
+			Overview = RefitFor(Organizations.WirelessController.Overview)
+		};
+
+	private OrganizationsWirelessControllerClientsSection BuildOrganizationsWirelessControllerClientsSection()
+		=> new()
+		{
+			Overview = new()
+			{
+				History = new()
+				{
+					ByDevice = RefitFor(Organizations.WirelessController.Clients.Overview.History.ByDevice)
+				}
+			}
+		};
+
+	private OrganizationsWirelessControllerDevicesSection BuildOrganizationsWirelessControllerDevicesSection()
+		=> new()
+		{
+			Interfaces = new()
+			{
+				L2 = RefitFor(Organizations.WirelessController.Devices.Interfaces.L2),
+				L3 = RefitFor(Organizations.WirelessController.Devices.Interfaces.L3),
+				Packets = RefitFor(Organizations.WirelessController.Devices.Interfaces.Packets),
+				Usage = RefitFor(Organizations.WirelessController.Devices.Interfaces.Usage)
+			},
+			Redundancy = RefitFor(Organizations.WirelessController.Devices.Redundancy),
+			System = new()
+			{
+				Utilization = new()
+				{
+					History = RefitFor(Organizations.WirelessController.Devices.System.Utilization.History)
+				}
+			}
 		};
 }
 #pragma warning restore S2333

--- a/Meraki.Api/MerakiClient.ProductSections.cs
+++ b/Meraki.Api/MerakiClient.ProductSections.cs
@@ -199,11 +199,21 @@ public partial class MerakiClient
 	private LiveToolsSection BuildLiveToolsSection()
 		=> new()
 		{
+			AclHitCount = RefitFor(LiveTools.AclHitCount),
 			ArpTable = RefitFor(LiveTools.ArpTable),
 			CableTest = RefitFor(LiveTools.CableTest),
+			CyclePort = RefitFor(LiveTools.CyclePort),
+			DhcpLeases = RefitFor(LiveTools.DhcpLeases),
+			Leds = RefitFor(LiveTools.Leds),
+			MacTable = RefitFor(LiveTools.MacTable),
+			MulticastRouting = RefitFor(LiveTools.MulticastRouting),
+			OspfNeighbors = RefitFor(LiveTools.OspfNeighbors),
 			Ping = RefitFor(LiveTools.Ping),
 			PingDevice = RefitFor(LiveTools.PingDevice),
+			RoutingTable = RefitFor(LiveTools.RoutingTable),
+			SpeedTest = RefitFor(LiveTools.SpeedTest),
 			ThroughputTest = RefitFor(LiveTools.ThroughputTest),
+			TraceRoute = RefitFor(LiveTools.TraceRoute),
 			WakeOnLan = RefitFor(LiveTools.WakeOnLan)
 		};
 
@@ -213,6 +223,10 @@ public partial class MerakiClient
 			Alerts = new()
 			{
 				Profiles = RefitFor(Sensor.Alerts.Profiles)
+			},
+			Gateways = new()
+			{
+				ConnectionsLatest = RefitFor(Sensor.Gateways.ConnectionsLatest)
 			},
 			Readings = new()
 			{

--- a/Meraki.Api/Sections/General/Devices/DevicesSection.cs
+++ b/Meraki.Api/Sections/General/Devices/DevicesSection.cs
@@ -12,7 +12,7 @@ public partial class DevicesSection
 	/// Gets the appliance
 	/// </summary>
 
-	public DevicesApplianceSection Appliance { get; set; } = null!;
+	public DevicesApplianceSection Appliance { get; set; } = new();
 
 	/// <summary>
 	/// List the clients of a device, up to a maximum of a month ago
@@ -48,7 +48,7 @@ public partial class DevicesSection
 	/// Gets the wireless
 	/// </summary>
 
-	public DevicesWirelessSection Wireless { get; internal set; } = null!;
+	public DevicesWirelessSection Wireless { get; internal set; } = new();
 
 	/// <summary>
 	/// Returns a historical log of all commands

--- a/Meraki.Api/Sections/General/Devices/DevicesWirelessSection.cs
+++ b/Meraki.Api/Sections/General/Devices/DevicesWirelessSection.cs
@@ -18,11 +18,11 @@ public partial class DevicesWirelessSection
 	/// Gets the radio
 	/// </summary>
 
-	public DevicesWirelessRadioSection Radio { get; internal set; } = null!;
+	public DevicesWirelessRadioSection Radio { get; internal set; } = new();
 
 	/// <summary>
 	/// Gets the zigbee
 	/// </summary>
 
-	public DevicesWirelessZigbeeSection Zigbee { get; internal set; } = null!;
+	public DevicesWirelessZigbeeSection Zigbee { get; internal set; } = new();
 }

--- a/Meraki.Api/Sections/General/Networks/NetworksSection.cs
+++ b/Meraki.Api/Sections/General/Networks/NetworksSection.cs
@@ -140,7 +140,7 @@ public partial class NetworksSection
 	/// Gets the switch
 	/// </summary>
 
-	public NetworksSwitchSection Switch { get; set; } = null!;
+	public NetworksSwitchSection Switch { get; set; } = new();
 	/// <summary>
 	/// List the splash login attempts for a network
 	/// </summary>

--- a/Meraki.Api/Sections/General/Organizations/OrganizationsCertificatesSection.cs
+++ b/Meraki.Api/Sections/General/Organizations/OrganizationsCertificatesSection.cs
@@ -15,5 +15,5 @@ public partial class OrganizationsCertificatesSection
 	/// Gets the rad sec
 	/// </summary>
 
-	public OrganizationsCertificatesRadSecSection RadSec { get; internal set; } = null!;
+	public OrganizationsCertificatesRadSecSection RadSec { get; internal set; } = new();
 }


### PR DESCRIPTION
Closes #357

## What

- **Wiring.** All 86 null entries the issue reported (82 Refit leaves, 4 sub-sections) are now assigned in the existing `Build*Section()` builders in `MerakiClient.GeneralSections.cs` and `MerakiClient.ProductSections.cs`, following the existing style. 26 new private builder methods were added where nesting warranted it; 8 existing ones gained entries.
- **Root cause of the four null sub-sections.** Six section-typed properties (`DevicesSection.Appliance`/`.Wireless`, `DevicesWirelessSection.Radio`/`.Zigbee`, `NetworksSection.Switch`, `OrganizationsCertificatesSection.RadSec`) defaulted to `= null!` where every other section property in the codebase defaults to `= new()`. They now match, which is also what lets the standard `RefitFor(Devices.Appliance.X)` inference pattern work for them.
- **Two credential-free guard tests** in the new `MerakiClientSectionCensusTests`:
  - `Constructor_LeavesNoSectionOrRefitClientNull` walks every public and internal property of the tree by reflection and lists any null with its full path. Failed on `main` with the issue's exact 86 entries; passes now.
  - `EveryRefitInterface_CanBeConstructed` builds every interface under `Meraki.Api.Interfaces` that has a Refit HTTP attribute, via the single-argument `RestService.For<T>(HttpClient)` overload (chosen deliberately, per the issue's warning about the `IRequestBuilder` overload). Interfaces with no HTTP attributes (`IRateLimiter`, the two SecureConnect deployment interfaces) are skipped.
- **One further defect found by the second test.** `IOrganizationsCameraDetections` threw at `RestService.For<T>`: "This interface needs the reflection request builder, which is not installed." The csproj suppresses RF006 on the stated basis that such methods fall back to the reflection builder, but that fallback only exists when `Refit.Reflection` is referenced, and it never was. It is now (15.2.0, matching Refit), and the csproj comment says so. Without this, the wiring change would have made `new MerakiClient(...)` throw for every consumer, exactly the failure mode the issue warned about.

## Not done, deliberately

- The reflection auto-wiring / source generator the issue proposes. The census test is what prevents recurrence; the hand-written builders remain readable and debuggable.
- The 19 interfaces referenced by no section property, and the `Organizations.NewtworkDevices` misspelling. Both are public-surface additions or breaks and deserve their own issues.

## Downstream

Purely additive for DNA.Assure, DNA.WiserWatts and Cae.Portal: properties that threw `NullReferenceException` now work. Construction builds about 90 more Refit proxies, adding a few tens of milliseconds per `new MerakiClient(...)`. Assure's `MerakiInventoryGateway` constructs a client per call by design and Portal constructs one per operation; neither is on a hot path, but the CHANGELOG notes it.

## Tests

273 credential-free unit tests pass (census, wiring, options, handler, pager, query, workflows, MCP, data). The five failures in a broad run are integration tests that need credentials, including two Environmental tests that dereference `Configuration` in their constructor before the fixture loads it, which is pre-existing.