### PR TITLE
fix: map seven scalar response fields the API returns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
         -class Meraki.Api.Test.Workflows.MerakiWorkflowsApiClientTests
         -noColor
 
+    - name: Data model unit tests
+      run: >-
+        dotnet run --project Meraki.Api.Test/Meraki.Api.Test.csproj
+        --configuration Release --no-build --
+        -namespace Meraki.Api.Test.Data
+        -noColor
+
     - name: Pack
       run: dotnet pack Meraki.Api/Meraki.Api.csproj --no-build --configuration Release --output ./artifacts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ﻿# Changelog
 
+## 1.70.135
+
+- **Seven more response fields the Dashboard API returns are now mapped**, all of them simple
+  scalars on classes that already existed. A sweep of unmapped-member reports gathered from live
+  organizations found them; callers who set `JsonMissingMemberHandling.ThrowOnError` were getting a
+  failed deserialization rather than an ignored field, so for them these were hard failures on
+  ordinary calls:
+  `VlanProfileDeviceAssignment.ConfigurationSource`, `ConfigTemplateSwitchProfilePort.ActiveVlans`,
+  `CameraQualityRetentionProfile.AxisVideoQuality`, `VpnBgp.PriorityRoute`,
+  `RoutingInterface.IsSwitchDefaultGateway`, and `TrafficShapingVpnExclusionsApplication.Protocol`
+  and `.Source`.
+
+  `ConfigurationSource` and `AxisVideoQuality` are in the v1.74.0 OpenAPI spec as response-only
+  fields; the rest appear nowhere in the spec and are mapped from the observed responses. All seven
+  are read-only, because none of them appears in a documented request body. `Protocol` reuses the
+  existing `TrafficShapingVpnExclusionsCustomProtocol` enum, matching
+  `TrafficShapingVpnExclusionsCustom`, on which both fields were already mapped.
+
+  Only the first unmapped field in a response is ever reported, so `.Source` was found by checking
+  every sibling key of a reported field rather than only the reported field itself.
+
+- **These mappings now have credential-free regression tests.**
+  `Meraki.Api.Test.Data.MissingMemberScalarFieldTests` deserializes the observed payloads (with
+  identifying values replaced) using `MissingMemberHandling.Error`, so an unmapped field fails the
+  test instead of being dropped.
+  CI gained a step that runs the whole `Meraki.Api.Test.Data` namespace, which previously ran no
+  tests in CI at all.
+
 ## 1.70.133
 
 - **Two more fields the Dashboard API returns are now mapped**: `ApiUsage.OperationId` (the

--- a/Meraki.Api.Test/Data/MissingMemberScalarFieldTests.cs
+++ b/Meraki.Api.Test/Data/MissingMemberScalarFieldTests.cs
@@ -1,0 +1,221 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for the scalar response fields that live organizations were observed to return
+/// with no matching model property. Each payload keeps the shape of a real Dashboard API response
+/// with identifying values replaced, and each test deserializes it with the same settings
+/// <see cref="JsonMissingMemberHandling.ThrowOnError"/> uses, so an unmapped field fails the test
+/// rather than being silently dropped.
+/// </summary>
+public class MissingMemberScalarFieldTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// GET /networks/{networkId}/vlanProfiles/assignments/byDevice
+	[Fact]
+	public void Deserialize_VlanProfileDeviceAssignment_MapsConfigurationSource()
+	{
+		const string json = """
+			{
+				"name": "AP-01",
+				"mac": "00:11:22:33:44:55",
+				"serial": "Q2XX-ABCD-1234",
+				"productType": "wireless",
+				"vlanProfile": {
+					"iname": "Default",
+					"name": "Default Profile",
+					"isDefault": true
+				},
+				"configurationSource": "Cloud",
+				"stack": {
+					"id": null,
+					"name": null
+				}
+			}
+			""";
+
+		var assignment = Deserialize<VlanProfileDeviceAssignment>(json);
+
+		_ = assignment.ConfigurationSource.Should().Be("Cloud");
+	}
+
+	// GET /organizations/{organizationId}/configTemplates/{configTemplateId}/switch/profiles/{profileId}/ports
+	[Fact]
+	public void Deserialize_ConfigTemplateSwitchProfilePort_MapsActiveVlans()
+	{
+		const string json = """
+			{
+				"portId": "1",
+				"name": "Client Access",
+				"tags": [],
+				"enabled": true,
+				"poeEnabled": true,
+				"type": "access",
+				"vlan": 50,
+				"voiceVlan": 60,
+				"allowedVlans": "all",
+				"activeVlans": "1-4094",
+				"isolationEnabled": false,
+				"rstpEnabled": true,
+				"stpGuard": "disabled",
+				"linkNegotiation": "Auto negotiate",
+				"portScheduleId": null,
+				"schedule": null,
+				"udld": "Alert only",
+				"linkNegotiationCapabilities": [
+					"Auto negotiate",
+					"1 Gigabit full duplex (auto)"
+				],
+				"accessPolicyType": "Open",
+				"daiTrusted": false,
+				"mirror": {
+					"mode": "Not mirroring traffic"
+				}
+			}
+			""";
+
+		var port = Deserialize<ConfigTemplateSwitchProfilePort>(json);
+
+		_ = port.ActiveVlans.Should().Be("1-4094");
+	}
+
+	// GET /networks/{networkId}/camera/qualityRetentionProfiles
+	// videoSettings is trimmed to two camera models; the full response lists every supported model.
+	[Fact]
+	public void Deserialize_CameraQualityRetentionProfile_MapsAxisVideoQuality()
+	{
+		const string json = """
+			{
+				"id": "220",
+				"name": "Default",
+				"restrictedBandwidthModeEnabled": false,
+				"motionBasedRetentionEnabled": false,
+				"audioRecordingEnabled": false,
+				"cloudArchiveEnabled": true,
+				"maxRetentionDays": null,
+				"scheduleId": null,
+				"motionDetectorVersion": 2,
+				"smartRetention": {
+					"enabled": false
+				},
+				"videoSettings": {
+					"MV2": {
+						"quality": "High",
+						"resolution": "1920x1080"
+					},
+					"MV44X": {
+						"quality": "Enhanced",
+						"resolution": "2560x1920"
+					}
+				},
+				"axisVideoQuality": "enhanced"
+			}
+			""";
+
+		var profile = Deserialize<CameraQualityRetentionProfile>(json);
+
+		_ = profile.AxisVideoQuality.Should().Be("enhanced");
+	}
+
+	// GET /networks/{networkId}/appliance/vpn/bgp
+	// The same response also carries ipv6 and tunnelDownTermination, which are mapped separately.
+	[Fact]
+	public void Deserialize_VpnBgp_MapsPriorityRoute()
+	{
+		const string json = """
+			{
+				"enabled": false,
+				"ibgpHoldTimer": 240,
+				"asNumber": 64512,
+				"routerId": null,
+				"priorityRoute": "Auto VPN",
+				"neighbors": []
+			}
+			""";
+
+		var bgp = Deserialize<VpnBgp>(json);
+
+		_ = bgp.PriorityRoute.Should().Be("Auto VPN");
+	}
+
+	// GET /devices/{serial}/switch/routing/interfaces
+	[Fact]
+	public void Deserialize_RoutingInterface_MapsIsSwitchDefaultGateway()
+	{
+		const string json = """
+			{
+				"interfaceId": "1234567890123456789",
+				"name": "Firewall Transit",
+				"subnet": "10.0.0.0/29",
+				"interfaceIp": "10.0.0.4",
+				"mtu": 0,
+				"multicastRouting": "disabled",
+				"vlanId": 500,
+				"defaultGateway": "10.0.0.1",
+				"ospfSettings": {
+					"area": "ospfDisabled"
+				},
+				"ospfV3": {
+					"area": "ospfV3Disabled"
+				},
+				"uplinkV4": true,
+				"uplinkV6": false,
+				"mode": "vlan",
+				"switchPortId": null,
+				"isSwitchDefaultGateway": false,
+				"candidateUplinkV4": true,
+				"staticV4Dns1": "8.8.8.8",
+				"staticV4Dns2": null,
+				"vrf": {
+					"name": "Default"
+				},
+				"vrrp": {
+					"ipv4": {
+						"enabled": false
+					},
+					"ipv6": {
+						"enabled": false
+					}
+				}
+			}
+			""";
+
+		var routingInterface = Deserialize<RoutingInterface>(json);
+
+		_ = routingInterface.IsSwitchDefaultGateway.Should().BeFalse();
+	}
+
+	// GET /organizations/{organizationId}/appliance/trafficShaping/vpnExclusions/byNetwork
+	[Fact]
+	public void Deserialize_TrafficShapingVpnExclusionsApplication_MapsProtocolAndSource()
+	{
+		const string json = """
+			{
+				"id": "meraki:layer7/application/1431",
+				"name": "Microsoft Office 365",
+				"protocol": "any",
+				"source": null
+			}
+			""";
+
+		var application = Deserialize<TrafficShapingVpnExclusionsApplication>(json);
+
+		_ = application.Protocol.Should().Be(TrafficShapingVpnExclusionsCustomProtocol.Any);
+		_ = application.Source.Should().BeNull();
+	}
+}

--- a/Meraki.Api/Data/CameraQualityRetentionProfile.cs
+++ b/Meraki.Api/Data/CameraQualityRetentionProfile.cs
@@ -19,4 +19,11 @@ public class CameraQualityRetentionProfile : CameraQualityRetentionProfileCreate
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "networkId")]
 	public string NetworkId { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Video quality settings applied to all Axis cameras
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "axisVideoQuality")]
+	public string? AxisVideoQuality { get; set; }
 }

--- a/Meraki.Api/Data/ConfigTemplateSwitchProfilePort.cs
+++ b/Meraki.Api/Data/ConfigTemplateSwitchProfilePort.cs
@@ -186,6 +186,13 @@ public class ConfigTemplateSwitchProfilePort : NamedItem
 	public string? AllowedVlans { get; set; }
 
 	/// <summary>
+	/// The VLANs currently active on the switch profile port - Undocumented, observed in responses only
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "activeVlans")]
+	public string? ActiveVlans { get; set; }
+
+	/// <summary>
 	/// Gets the link negotiation capabilities
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]

--- a/Meraki.Api/Data/RoutingInterface.cs
+++ b/Meraki.Api/Data/RoutingInterface.cs
@@ -98,6 +98,13 @@ public class RoutingInterface : NamedItem
 	public bool? CandidateUplinkV4 { get; set; }
 
 	/// <summary>
+	/// Whether this interface is the switch's default gateway - Undocumented, observed in responses only
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "isSwitchDefaultGateway")]
+	public bool? IsSwitchDefaultGateway { get; set; }
+
+	/// <summary>
 	/// The IPv6 settings of the interface
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadWrite)]

--- a/Meraki.Api/Data/TrafficShapingVpnExclusionsApplication.cs
+++ b/Meraki.Api/Data/TrafficShapingVpnExclusionsApplication.cs
@@ -19,4 +19,20 @@ public class TrafficShapingVpnExclusionsApplication
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "name")]
 	public string? Name { get; set; }
+
+	/// <summary>
+	/// Protocol. Valid values are 'any', 'dns', 'icmp', 'tcp', 'udp'.
+	/// Undocumented, observed in responses only.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "protocol")]
+	public TrafficShapingVpnExclusionsCustomProtocol? Protocol { get; set; }
+
+	/// <summary>
+	/// Source address for the VPN exclusion rule.
+	/// Undocumented, observed in responses only and always as null so far.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "source")]
+	public string? Source { get; set; }
 }

--- a/Meraki.Api/Data/VlanProfileDeviceAssignment.cs
+++ b/Meraki.Api/Data/VlanProfileDeviceAssignment.cs
@@ -7,6 +7,13 @@
 public class VlanProfileDeviceAssignment
 {
 	/// <summary>
+	/// Indicates whether the device configuration is managed by the cloud or the device
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "configurationSource")]
+	public string? ConfigurationSource { get; set; }
+
+	/// <summary>
 	/// MAC address of the device
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]

--- a/Meraki.Api/Data/VpnBgp.cs
+++ b/Meraki.Api/Data/VpnBgp.cs
@@ -35,6 +35,13 @@ public class VpnBgp
 	public string? RouterId { get; set; }
 
 	/// <summary>
+	/// Which route source BGP prefers, for example 'Auto VPN'. Undocumented property, observed in responses only.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "priorityRoute")]
+	public string? PriorityRoute { get; set; }
+
+	/// <summary>
 	/// List of BGP neighbors. This list replaces the existing set of neighbors. When absent, this field is not updated.
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadUpdate)]


### PR DESCRIPTION
## What

Maps seven simple scalar response fields that live organizations were observed to return with no matching model property. Callers who set `JsonMissingMemberHandling.ThrowOnError` were getting a failed deserialization rather than an ignored field, so for them these were hard failures on ordinary calls.

| Field | Type | Access | Source |
|---|---|---|---|
| `VlanProfileDeviceAssignment.ConfigurationSource` | `string?` | Read | v1.74.0 spec, response-only |
| `ConfigTemplateSwitchProfilePort.ActiveVlans` | `string?` | Read | Observed only |
| `CameraQualityRetentionProfile.AxisVideoQuality` | `string?` | Read | v1.74.0 spec, response-only |
| `VpnBgp.PriorityRoute` | `string?` | Read | Observed only |
| `RoutingInterface.IsSwitchDefaultGateway` | `bool?` | Read | Observed only |
| `TrafficShapingVpnExclusionsApplication.Protocol` | `TrafficShapingVpnExclusionsCustomProtocol?` | Read | Observed only |
| `TrafficShapingVpnExclusionsApplication.Source` | `string?` | Read | Observed only |

## Where the evidence came from

An `OrganizationStats` unmapped-member export covering 453 reports across many live organizations. Types were cross-checked against the v1.74.0 OpenAPI spec (downloaded with `.github/skills/meraki-api-update/Prepare-MerakiApiUpdate.ps1 -Latest`).

All seven are read-only because none of them appears in a documented request body. `Protocol` reuses the existing `TrafficShapingVpnExclusionsCustomProtocol` enum, matching `TrafficShapingVpnExclusionsCustom`, on which both `protocol` and `source` were already mapped.

Only the first unmapped field in a response is ever reported, so `.Source` was found by checking every sibling key of a reported field rather than only the reported field itself.

## Tests

New `Meraki.Api.Test.Data.MissingMemberScalarFieldTests` deserializes the observed payloads (identifying values replaced) with `MissingMemberHandling.Error` — the same settings the `ThrowOnError` path uses — so an unmapped field fails the test instead of being silently dropped. No credentials needed.

CI gained a `Data model unit tests` step running the whole `Meraki.Api.Test.Data` namespace, which previously ran no tests in CI at all.

```
Meraki.Api.Test  Total: 8, Errors: 0, Failed: 0, Skipped: 0
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s)
```

## Notes

- The changelog section is labelled `1.70.135` on the assumption this lands as one commit on top of `1.70.134`; a merge commit will shift the released number.
- `SwitchPort.ActiveVlans` (the device-level equivalent) is already mapped as `ReadUpdate` while this PR maps the config-template one as `Read`. Neither is in the spec; worth a follow-up decision on which is right.
- Follow-up PR [#413](https://github.com/panoramicdata/Meraki.Api/pull/413) (`fix/map-observed-nested-fields`) maps the seven nested objects from the same export and is based on this branch.