### PR TITLE
fix: map seven nested response objects the API returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 ﻿# Changelog
 
+## 1.70.136
+
+- **Seven more response fields the Dashboard API returns are now mapped**, each of them a nested
+  object that needed a new model class. As with the scalars in 1.70.135, callers who set
+  `JsonMissingMemberHandling.ThrowOnError` were getting a failed deserialization rather than an
+  ignored field:
+  `TwoPointFourGhzSettings.Dot11ax` and `FiveGhzSettings.Dot11ax`, `SwitchPort.PerpetualPoe` and
+  `.FastPoe`, `NetworkApplianceSsidRadiusServer.Radsec`, `Admin.OtherOrganizationAccounts`, and
+  `VpnBgp.Ipv6` and `.TunnelDownTermination`.
+
+  Ten new classes back them: `TwoPointFourGhzSettingsDot11ax`, `FiveGhzSettingsDot11ax`,
+  `SwitchPortPerpetualPoe`, `SwitchPortFastPoe`, `NetworkApplianceSsidRadiusServerRadsec`,
+  `AdminOtherOrganizationAccounts` and `AdminOtherOrganizationAccountsLockout`, `VpnBgpIpv6`,
+  `VpnBgpIpv6SinglePeering` and `VpnBgpTunnelDownTermination`.
+
+  `Dot11ax` on both bands and both PoE objects are in the v1.74.0 OpenAPI spec on request bodies as
+  well as responses, so they are writable: `Dot11ax` is read/write and the two PoE objects are
+  read/update, matching their endpoints. The spec also marks `axEnabled` deprecated in favour of
+  `dot11ax.enabled` on both bands, which the XML docs now say. `Radsec`,
+  `OtherOrganizationAccounts`, `Ipv6` and `TunnelDownTermination` appear nowhere in the spec and are
+  mapped read-only from the observed responses.
+
+- **These mappings have credential-free regression tests** in
+  `Meraki.Api.Test.Data.MissingMemberNestedFieldTests`, deserializing the observed payloads (with
+  identifying values replaced) using `MissingMemberHandling.Error`. The CI step added in 1.70.135
+  runs them.
+
 ## 1.70.135
 
 - **Seven more response fields the Dashboard API returns are now mapped**, all of them simple

--- a/Meraki.Api.Test/Data/MissingMemberNestedFieldTests.cs
+++ b/Meraki.Api.Test/Data/MissingMemberNestedFieldTests.cs
@@ -1,0 +1,224 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for the nested response objects that live organizations were observed to return
+/// with no matching model property. Each payload keeps the shape of a real Dashboard API response
+/// with identifying values replaced, and each test deserializes it with the same settings
+/// <see cref="JsonMissingMemberHandling.ThrowOnError"/> uses, so an unmapped field fails the test
+/// rather than being silently dropped.
+/// </summary>
+public class MissingMemberNestedFieldTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// twoFourGhzSettings from GET /networks/{networkId}/wireless/rfProfiles
+	[Fact]
+	public void Deserialize_TwoPointFourGhzSettings_MapsDot11ax()
+	{
+		const string json = """
+			{
+				"maxPower": 30,
+				"minPower": 5,
+				"minBitrate": 11,
+				"rxsop": null,
+				"validAutoChannels": [ 1, 6, 11 ],
+				"axEnabled": true,
+				"dot11ax": {
+					"enabled": true
+				}
+			}
+			""";
+
+		var settings = Deserialize<TwoPointFourGhzSettings>(json);
+
+		_ = settings.Dot11ax.Should().NotBeNull();
+		_ = settings.Dot11ax!.Enabled.Should().BeTrue();
+	}
+
+	// fiveGhzSettings from GET /networks/{networkId}/wireless/rfProfiles
+	[Fact]
+	public void Deserialize_FiveGhzSettings_MapsDot11ax()
+	{
+		const string json = """
+			{
+				"maxPower": 30,
+				"minPower": 8,
+				"minBitrate": 12,
+				"rxsop": null,
+				"validAutoChannels": [ 36, 40, 44, 48, 149, 153, 157, 161 ],
+				"channelWidth": "auto",
+				"dot11ax": {
+					"enabled": true
+				}
+			}
+			""";
+
+		var settings = Deserialize<FiveGhzSettings>(json);
+
+		_ = settings.Dot11ax.Should().NotBeNull();
+		_ = settings.Dot11ax!.Enabled.Should().BeTrue();
+	}
+
+	// GET /devices/{serial}/switch/ports
+	[Fact]
+	public void Deserialize_SwitchPort_MapsPerpetualPoeAndFastPoe()
+	{
+		const string json = """
+			{
+				"portId": "1",
+				"name": "Access Port",
+				"tags": [],
+				"enabled": true,
+				"poeEnabled": true,
+				"perpetualPoe": {
+					"enabled": false
+				},
+				"fastPoe": {
+					"enabled": false
+				},
+				"type": "trunk",
+				"vlan": 1,
+				"voiceVlan": null,
+				"allowedVlans": "all",
+				"activeVlans": "1-4094",
+				"isolationEnabled": false,
+				"rstpEnabled": true,
+				"stpGuard": "disabled",
+				"linkNegotiation": "Auto negotiate",
+				"portScheduleId": null,
+				"schedule": null,
+				"udld": "Alert only",
+				"linkNegotiationCapabilities": [
+					"Auto negotiate",
+					"1 Gigabit full duplex (auto)"
+				],
+				"accessPolicyType": "Open",
+				"daiTrusted": false,
+				"profile": {
+					"enabled": false,
+					"id": "",
+					"iname": null
+				},
+				"module": {
+					"model": null
+				},
+				"mirror": {
+					"mode": "Not mirroring traffic"
+				}
+			}
+			""";
+
+		var port = Deserialize<SwitchPort>(json);
+
+		_ = port.PerpetualPoe.Should().NotBeNull();
+		_ = port.PerpetualPoe!.Enabled.Should().BeFalse();
+		_ = port.FastPoe.Should().NotBeNull();
+		_ = port.FastPoe!.Enabled.Should().BeFalse();
+	}
+
+	// radiusServers from GET /networks/{networkId}/appliance/ssids
+	[Fact]
+	public void Deserialize_NetworkApplianceSsidRadiusServer_MapsRadsec()
+	{
+		const string json = """
+			{
+				"host": "192.0.2.10",
+				"port": 2654,
+				"id": "1234567890123456789",
+				"openRoamingCertificateId": null,
+				"caCertificate": null,
+				"radsec": {
+					"enabled": false,
+					"tlsIdleTimeout": 900
+				}
+			}
+			""";
+
+		var radiusServer = Deserialize<NetworkApplianceSsidRadiusServer>(json);
+
+		_ = radiusServer.Radsec.Should().NotBeNull();
+		_ = radiusServer.Radsec!.Enabled.Should().BeFalse();
+		_ = radiusServer.Radsec.TlsIdleTimeout.Should().Be(900);
+	}
+
+	// GET /organizations/{organizationId}/admins
+	[Fact]
+	public void Deserialize_Admin_MapsOtherOrganizationAccounts()
+	{
+		const string json = """
+			{
+				"id": "1234567890123456789",
+				"name": "Example Administrator",
+				"email": "admin@example.com",
+				"authenticationMethod": "Email",
+				"orgAccess": "full",
+				"accountStatus": "ok",
+				"otherOrganizationAccounts": {
+					"lockout": {
+						"isLocked": false
+					}
+				},
+				"twoFactorAuthEnabled": false,
+				"hasApiKey": true,
+				"lastActive": "2026-09-04T10:23:23Z",
+				"networks": [],
+				"tags": []
+			}
+			""";
+
+		var admin = Deserialize<Admin>(json);
+
+		_ = admin.OtherOrganizationAccounts.Should().NotBeNull();
+		_ = admin.OtherOrganizationAccounts!.Lockout.Should().NotBeNull();
+		_ = admin.OtherOrganizationAccounts.Lockout!.IsLocked.Should().BeFalse();
+	}
+
+	// GET /networks/{networkId}/appliance/vpn/bgp - the whole observed response, including the
+	// PriorityRoute scalar mapped alongside these two nested objects.
+	[Fact]
+	public void Deserialize_VpnBgp_MapsIpv6AndTunnelDownTermination()
+	{
+		const string json = """
+			{
+				"enabled": false,
+				"ibgpHoldTimer": 240,
+				"asNumber": 64512,
+				"routerId": null,
+				"priorityRoute": "Auto VPN",
+				"ipv6": {
+					"singlePeering": {
+						"enabled": false
+					}
+				},
+				"tunnelDownTermination": {
+					"enabled": null
+				},
+				"neighbors": []
+			}
+			""";
+
+		var bgp = Deserialize<VpnBgp>(json);
+
+		_ = bgp.PriorityRoute.Should().Be("Auto VPN");
+		_ = bgp.Ipv6.Should().NotBeNull();
+		_ = bgp.Ipv6!.SinglePeering.Should().NotBeNull();
+		_ = bgp.Ipv6.SinglePeering!.Enabled.Should().BeFalse();
+		_ = bgp.TunnelDownTermination.Should().NotBeNull();
+		_ = bgp.TunnelDownTermination!.Enabled.Should().BeNull();
+	}
+}

--- a/Meraki.Api/Data/Admin.cs
+++ b/Meraki.Api/Data/Admin.cs
@@ -75,4 +75,11 @@ public class Admin : NamedIdentifiedItem
 	[ApiAccess(ApiAccess.ReadCreate)]
 	[DataMember(Name = "camera")]
 	public List<AdminCameraAccess>? Camera { get; set; }
+
+	/// <summary>
+	/// The administrator's accounts in other organizations - Undocumented, observed in responses only
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "otherOrganizationAccounts")]
+	public AdminOtherOrganizationAccounts? OtherOrganizationAccounts { get; set; }
 }

--- a/Meraki.Api/Data/AdminOtherOrganizationAccounts.cs
+++ b/Meraki.Api/Data/AdminOtherOrganizationAccounts.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The administrator's accounts in other organizations - Undocumented, observed in responses only
+/// </summary>
+[DataContract]
+public class AdminOtherOrganizationAccounts
+{
+	/// <summary>
+	/// The lockout state of the administrator's accounts in other organizations
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "lockout")]
+	public AdminOtherOrganizationAccountsLockout? Lockout { get; set; }
+}

--- a/Meraki.Api/Data/AdminOtherOrganizationAccountsLockout.cs
+++ b/Meraki.Api/Data/AdminOtherOrganizationAccountsLockout.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The lockout state of an administrator's accounts in other organizations
+/// </summary>
+[DataContract]
+public class AdminOtherOrganizationAccountsLockout
+{
+	/// <summary>
+	/// Whether the administrator is locked out of their accounts in other organizations
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "isLocked")]
+	public bool? IsLocked { get; set; }
+}

--- a/Meraki.Api/Data/FiveGhzSettings.cs
+++ b/Meraki.Api/Data/FiveGhzSettings.cs
@@ -57,8 +57,16 @@ public class FiveGhzSettings
 
 	/// <summary>
 	/// Determines whether 802.11ax is enabled. Undocumented property.
+	/// Deprecated by the API in favour of <see cref="Dot11ax"/>.
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "axEnabled")]
 	public bool? AxEnabled { get; set; }
+
+	/// <summary>
+	/// IEEE 802.11ax (Wi-Fi 6) settings.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "dot11ax")]
+	public FiveGhzSettingsDot11ax? Dot11ax { get; set; }
 }

--- a/Meraki.Api/Data/FiveGhzSettingsDot11ax.cs
+++ b/Meraki.Api/Data/FiveGhzSettingsDot11ax.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// IEEE 802.11ax (Wi-Fi 6) settings for the 5Ghz band
+/// </summary>
+[DataContract]
+public class FiveGhzSettingsDot11ax
+{
+	/// <summary>
+	/// Determines whether IEEE 802.11ax (Wi-Fi 6) on the 5 GHz band is enabled. Can be either true or false. If false, we highly recommend disabling band steering. If omitted, the existing 5 GHz IEEE 802.11ax setting is preserved.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/NetworkApplianceSsidRadiusServer.cs
+++ b/Meraki.Api/Data/NetworkApplianceSsidRadiusServer.cs
@@ -47,4 +47,11 @@ public class NetworkApplianceSsidRadiusServer
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "secret")]
 	public string? Secret { get; set; }
+
+	/// <summary>
+	/// RADSEC settings for the RADIUS server - Undocumented, observed in responses only
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "radsec")]
+	public NetworkApplianceSsidRadiusServerRadsec? Radsec { get; set; }
 }

--- a/Meraki.Api/Data/NetworkApplianceSsidRadiusServerRadsec.cs
+++ b/Meraki.Api/Data/NetworkApplianceSsidRadiusServerRadsec.cs
@@ -1,0 +1,22 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// RADSEC settings for an appliance SSID RADIUS server - Undocumented, observed in responses only
+/// </summary>
+[DataContract]
+public class NetworkApplianceSsidRadiusServerRadsec
+{
+	/// <summary>
+	/// Whether RADSEC is enabled for the RADIUS server
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+
+	/// <summary>
+	/// The interval (in seconds) that determines how long a TLS session can remain idle for a RADSec server before it is automatically terminated
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "tlsIdleTimeout")]
+	public int? TlsIdleTimeout { get; set; }
+}

--- a/Meraki.Api/Data/SwitchPort.cs
+++ b/Meraki.Api/Data/SwitchPort.cs
@@ -43,6 +43,20 @@ public class SwitchPort : NamedItem
 	public bool PoeEnabled { get; set; }
 
 	/// <summary>
+	/// Perpetual PoE settings for the switch port.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "perpetualPoe")]
+	public SwitchPortPerpetualPoe? PerpetualPoe { get; set; }
+
+	/// <summary>
+	/// Fast PoE settings for the switch port.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "fastPoe")]
+	public SwitchPortFastPoe? FastPoe { get; set; }
+
+	/// <summary>
 	/// The type of the switch port ('trunk' or 'access')
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadUpdate)]

--- a/Meraki.Api/Data/SwitchPortFastPoe.cs
+++ b/Meraki.Api/Data/SwitchPortFastPoe.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Fast PoE settings for the switch port
+/// </summary>
+[DataContract]
+public class SwitchPortFastPoe
+{
+	/// <summary>
+	/// Whether Fast PoE is enabled. Fast PoE requires Perpetual PoE to be enabled. This field is returned for all physical switch ports, but can only be enabled on ports that support PoE HA.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/SwitchPortPerpetualPoe.cs
+++ b/Meraki.Api/Data/SwitchPortPerpetualPoe.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Perpetual PoE settings for the switch port
+/// </summary>
+[DataContract]
+public class SwitchPortPerpetualPoe
+{
+	/// <summary>
+	/// Whether Perpetual PoE is enabled. This field is returned for all physical switch ports, but can only be enabled on ports that support PoE HA.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/TwoPointFourGhzSettings.cs
+++ b/Meraki.Api/Data/TwoPointFourGhzSettings.cs
@@ -36,10 +36,18 @@ public class TwoPointFourGhzSettings
 
 	/// <summary>
 	/// Determines whether ax radio on 2.4Ghz band is on or off. Can be either true or false. If false, we highly recommend disabling band steering. Defaults to true.
+	/// Deprecated by the API in favour of <see cref="Dot11ax"/>.
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "axEnabled")]
 	public bool? AxEnabled { get; set; }
+
+	/// <summary>
+	/// IEEE 802.11ax (Wi-Fi 6) settings.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "dot11ax")]
+	public TwoPointFourGhzSettingsDot11ax? Dot11ax { get; set; }
 
 	/// <summary>
 	/// The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after     consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will     reset this to the default.

--- a/Meraki.Api/Data/TwoPointFourGhzSettingsDot11ax.cs
+++ b/Meraki.Api/Data/TwoPointFourGhzSettingsDot11ax.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// IEEE 802.11ax (Wi-Fi 6) settings for the 2.4Ghz band
+/// </summary>
+[DataContract]
+public class TwoPointFourGhzSettingsDot11ax
+{
+	/// <summary>
+	/// Determines whether IEEE 802.11ax (Wi-Fi 6) on the 2.4 GHz band is enabled. Can be either true or false. If false, we highly recommend disabling band steering. If omitted, the existing 2.4 GHz IEEE 802.11ax setting is preserved.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/VpnBgp.cs
+++ b/Meraki.Api/Data/VpnBgp.cs
@@ -42,6 +42,20 @@ public class VpnBgp
 	public string? PriorityRoute { get; set; }
 
 	/// <summary>
+	/// IPv6 BGP settings. Undocumented property, observed in responses only.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "ipv6")]
+	public VpnBgpIpv6? Ipv6 { get; set; }
+
+	/// <summary>
+	/// BGP tunnel down termination settings. Undocumented property, observed in responses only.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "tunnelDownTermination")]
+	public VpnBgpTunnelDownTermination? TunnelDownTermination { get; set; }
+
+	/// <summary>
 	/// List of BGP neighbors. This list replaces the existing set of neighbors. When absent, this field is not updated.
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadUpdate)]

--- a/Meraki.Api/Data/VpnBgpIpv6.cs
+++ b/Meraki.Api/Data/VpnBgpIpv6.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// IPv6 BGP settings - Undocumented, observed in responses only
+/// </summary>
+[DataContract]
+public class VpnBgpIpv6
+{
+	/// <summary>
+	/// Single peering settings for IPv6 BGP
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "singlePeering")]
+	public VpnBgpIpv6SinglePeering? SinglePeering { get; set; }
+}

--- a/Meraki.Api/Data/VpnBgpIpv6SinglePeering.cs
+++ b/Meraki.Api/Data/VpnBgpIpv6SinglePeering.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Single peering settings for IPv6 BGP
+/// </summary>
+[DataContract]
+public class VpnBgpIpv6SinglePeering
+{
+	/// <summary>
+	/// Whether a single IPv6 BGP peering session is used
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/VpnBgpTunnelDownTermination.cs
+++ b/Meraki.Api/Data/VpnBgpTunnelDownTermination.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// BGP tunnel down termination settings - Undocumented, observed in responses only
+/// </summary>
+[DataContract]
+public class VpnBgpTunnelDownTermination
+{
+	/// <summary>
+	/// Whether BGP sessions are terminated when the tunnel goes down
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}


### PR DESCRIPTION
## What

Stacked on [#412](https://github.com/panoramicdata/Meraki.Api/pull/412) — **base is `fix/map-observed-scalar-fields`, so merge #412 first**, after which this can be retargeted to `main`.

The same unmapped-member export that found #412's scalars also found seven nested objects with no model property. Callers who set `JsonMissingMemberHandling.ThrowOnError` were getting a failed deserialization rather than an ignored field.

| Field | Type | Access | Source |
|---|---|---|---|
| `TwoPointFourGhzSettings.Dot11ax` | `TwoPointFourGhzSettingsDot11ax?` | ReadWrite | v1.74.0 spec, request + response |
| `FiveGhzSettings.Dot11ax` | `FiveGhzSettingsDot11ax?` | ReadWrite | v1.74.0 spec, request + response |
| `SwitchPort.PerpetualPoe` | `SwitchPortPerpetualPoe?` | ReadUpdate | v1.74.0 spec, request + response |
| `SwitchPort.FastPoe` | `SwitchPortFastPoe?` | ReadUpdate | v1.74.0 spec, request + response |
| `NetworkApplianceSsidRadiusServer.Radsec` | `NetworkApplianceSsidRadiusServerRadsec?` | Read | Observed only |
| `Admin.OtherOrganizationAccounts` | `AdminOtherOrganizationAccounts?` | Read | Observed only |
| `VpnBgp.Ipv6` | `VpnBgpIpv6?` | Read | Observed only |
| `VpnBgp.TunnelDownTermination` | `VpnBgpTunnelDownTermination?` | Read | Observed only |

## New classes

Ten, each named after its owner in line with the existing `SwitchPortDot3az` / `ConfigTemplateSwitchProfilePortDot3az` split rather than sharing one `enabled`-only type:

`TwoPointFourGhzSettingsDot11ax`, `FiveGhzSettingsDot11ax`, `SwitchPortPerpetualPoe`, `SwitchPortFastPoe`, `NetworkApplianceSsidRadiusServerRadsec`, `AdminOtherOrganizationAccounts`, `AdminOtherOrganizationAccountsLockout`, `VpnBgpIpv6`, `VpnBgpIpv6SinglePeering`, `VpnBgpTunnelDownTermination`.

## Access decisions

`Dot11ax` on both bands and both PoE objects appear in v1.74.0 request bodies as well as responses, so they are writable. The spec also marks `axEnabled` deprecated in favour of `dot11ax.enabled` on both bands, which the XML docs now say — no behaviour change, `AxEnabled` is left in place.

`Radsec`, `OtherOrganizationAccounts`, `Ipv6` and `TunnelDownTermination` appear nowhere in the spec and are mapped read-only from the observed responses.

## Tests

New `Meraki.Api.Test.Data.MissingMemberNestedFieldTests`, same approach as #412: observed payloads (identifying values replaced) deserialized with `MissingMemberHandling.Error`. Run by the CI step #412 adds.

```
Meraki.Api.Test (Data namespace)  Total: 14, Errors: 0, Failed: 0, Skipped: 0
Meraki.Api.Test (Workflows)       Total: 12, Errors: 0, Failed: 0, Skipped: 0
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s)
```

## Notes

- Changelog section labelled `1.70.136`, one above #412's; merge commits will shift the released number.
- `SixGhzSettings` has no `dot11ax` in the spec or in any observed response, so it is untouched.
