### PR TITLE
chore: track Dashboard API 1.74 and add the model gap diff

### DIFF
--- a/.github/skills/meraki-api-update/Find-MissingModelMembers.ps1
+++ b/.github/skills/meraki-api-update/Find-MissingModelMembers.ps1
@@ -1,0 +1,295 @@
+<#
+.SYNOPSIS
+	Reports response members present in a versioned Meraki OpenAPI spec but absent from the
+	Meraki.Api models.
+
+.DESCRIPTION
+	Matches every Refit interface method's verb and path template to a spec operation, then walks
+	that operation's 2xx JSON response schema in parallel with the C# return type, comparing spec
+	property names against [DataMember] names.
+
+	Three classes of legitimate mismatch are excluded, because the spec describes them as ordinary
+	properties while the models represent them as open-ended maps or as no payload at all:
+
+	- Dictionary-typed models (HTTP status-code maps, per-camera-model video settings).
+	- Methods declared to return the non-generic Task.
+	- Purely numeric property names (latency histogram buckets, HTTP status codes).
+
+	The solution must be built before running this, because the report is produced by reflecting
+	over the compiled assembly. Dependencies are probed from the test project's output directory,
+	which is the only place every transitive dependency sits beside Meraki.Api.dll.
+
+.PARAMETER SpecVersion
+	Spec folder under tmp/meraki-api-update, for example v1.74.0. Fetch it first with
+	Prepare-MerakiApiUpdate.ps1.
+
+.PARAMETER OutCsv
+	Optional path to write the full findings to as CSV.
+
+.EXAMPLE
+	pwsh -File .\.github\skills\meraki-api-update\Find-MissingModelMembers.ps1 -SpecVersion v1.74.0 -OutCsv gap.csv
+#>
+[CmdletBinding()]
+param(
+	[Parameter(Mandatory = $true)]
+	[string]$SpecVersion,
+
+	[string]$RepoRoot,
+
+	[string]$Configuration = 'Debug',
+
+	[string]$TargetFramework = 'net10.0',
+
+	[string]$OutCsv
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$InformationPreference = 'Continue'
+
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+	$RepoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\..'))
+}
+
+$probeDirectory = Join-Path $RepoRoot "Meraki.Api.Test\bin\$Configuration\$TargetFramework"
+if (-not (Test-Path -LiteralPath $probeDirectory)) {
+	throw "Build the solution first: '$probeDirectory' does not exist."
+}
+$probeDirectory = (Resolve-Path -LiteralPath $probeDirectory).Path
+
+$specPath = Join-Path $RepoRoot "tmp\meraki-api-update\$SpecVersion\spec3.json"
+if (-not (Test-Path -LiteralPath $specPath)) {
+	throw "Spec not found at '$specPath'. Fetch it with Prepare-MerakiApiUpdate.ps1 -Version $SpecVersion."
+}
+
+# Meraki.Api.dll alone cannot be reflected over: GetTypes() needs Refit and the logging
+# abstractions, which only sit beside the assembly in the test project's output.
+$resolveHandler = [System.ResolveEventHandler] {
+	param($sender, $eventArgs)
+	$simpleName = ($eventArgs.Name -split ',')[0]
+	$candidate = Join-Path $probeDirectory "$simpleName.dll"
+	if (Test-Path -LiteralPath $candidate) { [System.Reflection.Assembly]::LoadFrom($candidate) } else { $null }
+}
+[System.AppDomain]::CurrentDomain.add_AssemblyResolve($resolveHandler)
+$assembly = [System.Reflection.Assembly]::LoadFrom((Join-Path $probeDirectory 'Meraki.Api.dll'))
+
+function Get-NormalizedPath {
+	param([Parameter(Mandatory = $true)][string]$Path)
+
+	$value = $Path
+	if (-not $value.StartsWith('/')) { $value = "/$value" }
+	# Parameter names differ between the Refit attributes and the spec, so compare structure only.
+	return ([regex]::Replace($value, '\{[^}]*\}', '{}')).TrimEnd('/').ToLowerInvariant()
+}
+
+# ---- Refit endpoints ---------------------------------------------------------------------------
+$endpoints = [System.Collections.Generic.List[object]]::new()
+$interfaces = $assembly.GetTypes() |
+	Where-Object { $_.IsInterface -and $_.Namespace -and $_.Namespace.StartsWith('Meraki.Api.Interfaces') }
+foreach ($interface in $interfaces) {
+	foreach ($method in $interface.GetMethods()) {
+		$httpAttributes = @(
+			$method.GetCustomAttributes($true) |
+				Where-Object { $_.GetType().FullName -like 'Refit.*' -and ($_.PSObject.Properties.Name -contains 'Path') }
+		)
+		if ($httpAttributes.Count -eq 0) { continue }
+		$endpoints.Add([PSCustomObject]@{
+				Verb       = "$($httpAttributes[0].Method)".ToLowerInvariant()
+				Path       = $httpAttributes[0].Path
+				ReturnType = $method.ReturnType
+				Interface  = $interface.Name
+				MethodName = $method.Name
+			})
+	}
+}
+Write-Information "Refit endpoints found: $($endpoints.Count)"
+
+# ---- Spec operations ---------------------------------------------------------------------------
+$spec = Get-Content -LiteralPath $specPath -Raw | ConvertFrom-Json -Depth 100
+$specOperations = @{}
+foreach ($pathProperty in $spec.paths.PSObject.Properties) {
+	$normalized = Get-NormalizedPath -Path $pathProperty.Name
+	foreach ($verbProperty in $pathProperty.Value.PSObject.Properties) {
+		$verb = $verbProperty.Name.ToLowerInvariant()
+		if ($verb -notin @('get', 'post', 'put', 'delete')) { continue }
+		$specOperations["$verb $normalized"] = $verbProperty.Value
+	}
+}
+Write-Information "Spec operations found: $($specOperations.Count)"
+
+# ---- CLR type helpers --------------------------------------------------------------------------
+function Get-PayloadType {
+	param([Parameter(Mandatory = $true)][Type]$Type)
+
+	$current = $Type
+	while ($current.IsGenericType -and $current.GetGenericTypeDefinition().Name -in @('Task`1', 'ValueTask`1', 'ApiResponse`1', 'IApiResponse`1')) {
+		$current = $current.GetGenericArguments()[0]
+	}
+	return $current
+}
+
+function Get-ElementType {
+	param([Parameter(Mandatory = $true)][Type]$Type)
+
+	if ($Type.IsArray) { return $Type.GetElementType() }
+	if ($Type.IsGenericType -and $Type.GetGenericTypeDefinition().Name -in @('List`1', 'IList`1', 'ICollection`1', 'IEnumerable`1', 'IReadOnlyList`1')) {
+		return $Type.GetGenericArguments()[0]
+	}
+	return $null
+}
+
+$script:memberCache = @{}
+function Get-JsonMemberMap {
+	param([Parameter(Mandatory = $true)][Type]$Type)
+
+	if ($script:memberCache.ContainsKey($Type.FullName)) { return $script:memberCache[$Type.FullName] }
+	$map = @{}
+	foreach ($property in $Type.GetProperties()) {
+		$dataMembers = @($property.GetCustomAttributes([System.Runtime.Serialization.DataMemberAttribute], $true))
+		$name = if ($dataMembers.Count -gt 0 -and $dataMembers[0].Name) { $dataMembers[0].Name } else { $property.Name }
+		if (-not $map.ContainsKey($name)) { $map[$name] = $property.PropertyType }
+	}
+	$script:memberCache[$Type.FullName] = $map
+	return $map
+}
+
+function Test-OpaqueType {
+	param([Type]$Type)
+
+	if ($null -eq $Type) { return $true }
+	$underlying = [Nullable]::GetUnderlyingType($Type)
+	if ($underlying) { $Type = $underlying }
+	if ($Type.IsPrimitive -or $Type.IsEnum) { return $true }
+	if ($Type.FullName -in @('System.Threading.Tasks.Task', 'System.Void')) { return $true }
+	if ($Type.IsGenericType -and $Type.GetGenericTypeDefinition().Name -in @('Dictionary`2', 'IDictionary`2', 'IReadOnlyDictionary`2', 'SortedDictionary`2')) { return $true }
+	return $Type.FullName -in @('System.String', 'System.Object', 'System.DateTime', 'System.DateTimeOffset', 'System.TimeSpan', 'System.Decimal', 'System.Guid')
+}
+
+function Resolve-Schema {
+	param($Schema)
+
+	if ($null -eq $Schema) { return $null }
+	if ($Schema.PSObject.Properties.Name -notcontains 'allOf') { return $Schema }
+
+	$properties = @{}
+	foreach ($subSchema in $Schema.allOf) {
+		$resolved = Resolve-Schema -Schema $subSchema
+		if ($resolved -and ($resolved.PSObject.Properties.Name -contains 'properties') -and $resolved.properties) {
+			foreach ($property in $resolved.properties.PSObject.Properties) { $properties[$property.Name] = $property.Value }
+		}
+	}
+	return [PSCustomObject]@{ type = 'object'; properties = [PSCustomObject]$properties }
+}
+
+# ---- Parallel walk -----------------------------------------------------------------------------
+$script:findings = [System.Collections.Generic.List[object]]::new()
+$script:visited = [System.Collections.Generic.HashSet[string]]::new()
+
+function Compare-Schema {
+	param($Schema, [Type]$ClrType, [string]$Breadcrumb, [int]$Depth, [string]$OperationId)
+
+	if ($Depth -gt 8 -or $null -eq $Schema -or $null -eq $ClrType) { return }
+	$Schema = Resolve-Schema -Schema $Schema
+	if ($null -eq $Schema) { return }
+
+	$schemaKeys = $Schema.PSObject.Properties.Name
+	$schemaType = if ($schemaKeys -contains 'type') { "$($Schema.type)" } else { '' }
+
+	if ($schemaType -eq 'array' -or ($schemaKeys -contains 'items')) {
+		$elementType = Get-ElementType -Type $ClrType
+		if ($null -eq $elementType) { $elementType = $ClrType }
+		if ($schemaKeys -contains 'items') {
+			Compare-Schema -Schema $Schema.items -ClrType $elementType -Breadcrumb $Breadcrumb -Depth ($Depth + 1) -OperationId $OperationId
+		}
+		return
+	}
+
+	if ($schemaKeys -notcontains 'properties' -or $null -eq $Schema.properties) { return }
+
+	$underlying = [Nullable]::GetUnderlyingType($ClrType)
+	if ($underlying) { $ClrType = $underlying }
+	$elementType = Get-ElementType -Type $ClrType
+	if ($elementType) { $ClrType = $elementType }
+	if (Test-OpaqueType -Type $ClrType) { return }
+
+	if (-not $script:visited.Add("$($ClrType.FullName)|$Breadcrumb")) { return }
+
+	$members = Get-JsonMemberMap -Type $ClrType
+	foreach ($specProperty in $Schema.properties.PSObject.Properties) {
+		$jsonName = $specProperty.Name
+		if ($members.ContainsKey($jsonName)) {
+			Compare-Schema -Schema $specProperty.Value -ClrType $members[$jsonName] -Breadcrumb "$Breadcrumb.$jsonName" -Depth ($Depth + 1) -OperationId $OperationId
+			continue
+		}
+
+		$value = $specProperty.Value
+		$description = if ($value -and ($value.PSObject.Properties.Name -contains 'description')) { "$($value.description)" } else { '' }
+		$jsonType = if ($value -and ($value.PSObject.Properties.Name -contains 'type')) { "$($value.type)" } else { '' }
+		$script:findings.Add([PSCustomObject]@{
+				ClrType     = $ClrType.Name
+				JsonMember  = $jsonName
+				JsonType    = $jsonType
+				Breadcrumb  = $Breadcrumb
+				OperationId = $OperationId
+				Description = $description
+			})
+	}
+}
+
+$matchedCount = 0
+$unmatched = [System.Collections.Generic.List[string]]::new()
+foreach ($endpoint in $endpoints) {
+	$key = "$($endpoint.Verb) $(Get-NormalizedPath -Path $endpoint.Path)"
+	if (-not $specOperations.ContainsKey($key)) {
+		$unmatched.Add("$key ($($endpoint.Interface).$($endpoint.MethodName))")
+		continue
+	}
+	$matchedCount++
+
+	$operation = $specOperations[$key]
+	if ($operation.PSObject.Properties.Name -notcontains 'responses') { continue }
+	$successName = @($operation.responses.PSObject.Properties.Name | Where-Object { $_ -match '^2' }) | Select-Object -First 1
+	if (-not $successName) { continue }
+	$success = $operation.responses.$successName
+	if ($success.PSObject.Properties.Name -notcontains 'content') { continue }
+	$jsonContent = $success.content.PSObject.Properties | Where-Object { $_.Name -like 'application/json*' } | Select-Object -First 1
+	if (-not $jsonContent -or ($jsonContent.Value.PSObject.Properties.Name -notcontains 'schema')) { continue }
+
+	$payloadType = Get-PayloadType -Type $endpoint.ReturnType
+	$operationId = if ($operation.PSObject.Properties.Name -contains 'operationId') { "$($operation.operationId)" } else { $key }
+	Compare-Schema -Schema $jsonContent.Value.schema -ClrType $payloadType -Breadcrumb $payloadType.Name -Depth 0 -OperationId $operationId
+}
+
+Write-Information "Endpoints matched to a spec operation: $matchedCount"
+Write-Information "Endpoints with no spec match: $($unmatched.Count)"
+
+$notImplemented = @($specOperations.Keys | Where-Object { $key = $_; -not ($endpoints | Where-Object { "$($_.Verb) $(Get-NormalizedPath -Path $_.Path)" -eq $key }) })
+Write-Information "Spec operations not implemented: $($notImplemented.Count)"
+
+# Purely numeric names are histogram buckets or HTTP status codes: an open-ended map, not a member.
+$realFindings = @($script:findings | Where-Object { $_.JsonMember -notmatch '^\d+(\.\d+)?$' })
+
+$grouped = $realFindings |
+	Group-Object { "$($_.ClrType)|$($_.JsonMember)" } |
+	ForEach-Object {
+		$first = $_.Group[0]
+		[PSCustomObject]@{
+			ClrType      = $first.ClrType
+			JsonMember   = $first.JsonMember
+			JsonType     = $first.JsonType
+			Hits         = $_.Count
+			OperationIds = (($_.Group.OperationId | Sort-Object -Unique) -join '; ')
+			Breadcrumb   = $first.Breadcrumb
+			Description  = $first.Description
+		}
+	} |
+	Sort-Object ClrType, JsonMember
+
+Write-Information "Unmapped response members: $(@($grouped).Count) across $(@($grouped.ClrType | Sort-Object -Unique).Count) types"
+
+if ($OutCsv) {
+	$grouped | Export-Csv -LiteralPath $OutCsv -NoTypeInformation -Encoding UTF8
+	Write-Information "Wrote $OutCsv"
+}
+
+return $grouped

--- a/.github/skills/meraki-api-update/Find-ModelShapeMismatches.ps1
+++ b/.github/skills/meraki-api-update/Find-ModelShapeMismatches.ps1
@@ -1,0 +1,322 @@
+<#
+.SYNOPSIS
+	Reports places where a Meraki.Api model disagrees with a versioned OpenAPI spec in shape rather
+	than in membership: wrong return-type shape, and property names that look like misspellings of a
+	spec name.
+
+.DESCRIPTION
+	Find-MissingModelMembers.ps1 compares names one way (spec to model) and so reports a wrong return
+	type as a pile of missing members. This script asks the two questions that separates cannot:
+
+	1. Shape. For each Refit method matched to a spec operation, does the 2xx schema's top-level shape
+	   agree with the return type? An {items, meta} wrapper returned into a List<T>, or a bare array
+	   returned into a single object, means the call cannot deserialize at all.
+
+	2. Spelling. At each object level walked in parallel, is there a [DataMember] name that is absent
+	   from the spec but within a small edit distance of a spec property that is itself unmapped? That
+	   is the signature of a typo such as "intiator" for "initiator": the property has never bound.
+
+	Members that are absent from the spec with no near match are not reported. Many are deliberately
+	mapped from observed responses the spec omits.
+
+	Build the solution before running this; it reflects over the compiled assembly.
+
+.PARAMETER SpecVersion
+	Spec folder under tmp/meraki-api-update, for example v1.74.0.
+
+.EXAMPLE
+	pwsh -File .\.github\skills\meraki-api-update\Find-ModelShapeMismatches.ps1 -SpecVersion v1.74.0
+#>
+[CmdletBinding()]
+param(
+	[Parameter(Mandatory = $true)]
+	[string]$SpecVersion,
+
+	[string]$RepoRoot,
+
+	[string]$Configuration = 'Debug',
+
+	[string]$TargetFramework = 'net10.0',
+
+	[int]$MaxEditDistance = 2,
+
+	[string]$OutCsv
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$InformationPreference = 'Continue'
+
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+	$RepoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\..'))
+}
+
+$probeDirectory = Join-Path $RepoRoot "Meraki.Api.Test\bin\$Configuration\$TargetFramework"
+if (-not (Test-Path -LiteralPath $probeDirectory)) { throw "Build the solution first: '$probeDirectory' does not exist." }
+$probeDirectory = (Resolve-Path -LiteralPath $probeDirectory).Path
+
+$specPath = Join-Path $RepoRoot "tmp\meraki-api-update\$SpecVersion\spec3.json"
+if (-not (Test-Path -LiteralPath $specPath)) { throw "Spec not found at '$specPath'. Fetch it with Prepare-MerakiApiUpdate.ps1." }
+
+$resolveHandler = [System.ResolveEventHandler] {
+	param($sender, $eventArgs)
+	$simpleName = ($eventArgs.Name -split ',')[0]
+	$candidate = Join-Path $probeDirectory "$simpleName.dll"
+	if (Test-Path -LiteralPath $candidate) { [System.Reflection.Assembly]::LoadFrom($candidate) } else { $null }
+}
+[System.AppDomain]::CurrentDomain.add_AssemblyResolve($resolveHandler)
+$assembly = [System.Reflection.Assembly]::LoadFrom((Join-Path $probeDirectory 'Meraki.Api.dll'))
+
+function Get-NormalizedPath {
+	param([Parameter(Mandatory = $true)][string]$Path)
+	$value = $Path
+	if (-not $value.StartsWith('/')) { $value = "/$value" }
+	return ([regex]::Replace($value, '\{[^}]*\}', '{}')).TrimEnd('/').ToLowerInvariant()
+}
+
+function Get-PayloadType {
+	param([Parameter(Mandatory = $true)][Type]$Type)
+	$current = $Type
+	while ($current.IsGenericType -and $current.GetGenericTypeDefinition().Name -in @('Task`1', 'ValueTask`1', 'ApiResponse`1', 'IApiResponse`1')) {
+		$current = $current.GetGenericArguments()[0]
+	}
+	return $current
+}
+
+function Get-ElementType {
+	param([Parameter(Mandatory = $true)][Type]$Type)
+	if ($Type.IsArray) { return $Type.GetElementType() }
+	if ($Type.IsGenericType -and $Type.GetGenericTypeDefinition().Name -in @('List`1', 'IList`1', 'ICollection`1', 'IEnumerable`1', 'IReadOnlyList`1')) {
+		return $Type.GetGenericArguments()[0]
+	}
+	return $null
+}
+
+function Test-DictionaryType {
+	param([Type]$Type)
+	return $Type.IsGenericType -and $Type.GetGenericTypeDefinition().Name -in @('Dictionary`2', 'IDictionary`2', 'IReadOnlyDictionary`2', 'SortedDictionary`2')
+}
+
+function Test-OpaqueType {
+	param([Type]$Type)
+	if ($null -eq $Type) { return $true }
+	$underlying = [Nullable]::GetUnderlyingType($Type)
+	if ($underlying) { $Type = $underlying }
+	if ($Type.IsPrimitive -or $Type.IsEnum) { return $true }
+	if ($Type.FullName -in @('System.Threading.Tasks.Task', 'System.Void')) { return $true }
+	if (Test-DictionaryType -Type $Type) { return $true }
+	return $Type.FullName -in @('System.String', 'System.Object', 'System.DateTime', 'System.DateTimeOffset', 'System.TimeSpan', 'System.Decimal', 'System.Guid')
+}
+
+$script:memberCache = @{}
+function Get-JsonMemberMap {
+	param([Parameter(Mandatory = $true)][Type]$Type)
+	if ($script:memberCache.ContainsKey($Type.FullName)) { return $script:memberCache[$Type.FullName] }
+	$map = [ordered]@{}
+	foreach ($property in $Type.GetProperties()) {
+		$dataMembers = @($property.GetCustomAttributes([System.Runtime.Serialization.DataMemberAttribute], $true))
+		$name = if ($dataMembers.Count -gt 0 -and $dataMembers[0].Name) { $dataMembers[0].Name } else { $property.Name }
+		if (-not $map.Contains($name)) { $map[$name] = [PSCustomObject]@{ Type = $property.PropertyType; Property = $property.Name } }
+	}
+	$script:memberCache[$Type.FullName] = $map
+	return $map
+}
+
+function Resolve-Schema {
+	param($Schema)
+	if ($null -eq $Schema) { return $null }
+	if ($Schema.PSObject.Properties.Name -notcontains 'allOf') { return $Schema }
+	$properties = @{}
+	foreach ($subSchema in $Schema.allOf) {
+		$resolved = Resolve-Schema -Schema $subSchema
+		if ($resolved -and ($resolved.PSObject.Properties.Name -contains 'properties') -and $resolved.properties) {
+			foreach ($property in $resolved.properties.PSObject.Properties) { $properties[$property.Name] = $property.Value }
+		}
+	}
+	return [PSCustomObject]@{ type = 'object'; properties = [PSCustomObject]$properties }
+}
+
+function Get-SchemaKind {
+	param($Schema)
+	if ($null -eq $Schema) { return 'none' }
+	$keys = $Schema.PSObject.Properties.Name
+	if (($keys -contains 'type' -and "$($Schema.type)" -eq 'array') -or ($keys -contains 'items')) { return 'array' }
+	if (($keys -contains 'type' -and "$($Schema.type)" -eq 'object') -or ($keys -contains 'properties') -or ($keys -contains 'allOf')) { return 'object' }
+	if ($keys -contains 'type') { return "$($Schema.type)" }
+	return 'unknown'
+}
+
+function Get-EditDistance {
+	param([string]$A, [string]$B)
+	$a = $A.ToLowerInvariant(); $b = $B.ToLowerInvariant()
+	if ($a -eq $b) { return 0 }
+	$m = $a.Length; $n = $b.Length
+	if ($m -eq 0) { return $n }
+	if ($n -eq 0) { return $m }
+	$previous = 0..$n
+	for ($i = 1; $i -le $m; $i++) {
+		$current = New-Object int[] ($n + 1)
+		$current[0] = $i
+		for ($j = 1; $j -le $n; $j++) {
+			$cost = if ($a[$i - 1] -eq $b[$j - 1]) { 0 } else { 1 }
+			$current[$j] = [Math]::Min([Math]::Min($previous[$j] + 1, $current[$j - 1] + 1), $previous[$j - 1] + $cost)
+		}
+		$previous = $current
+	}
+	return $previous[$n]
+}
+
+# ---- Refit endpoints and spec operations -------------------------------------------------------
+$endpoints = [System.Collections.Generic.List[object]]::new()
+$interfaces = $assembly.GetTypes() | Where-Object { $_.IsInterface -and $_.Namespace -and $_.Namespace.StartsWith('Meraki.Api.Interfaces') }
+foreach ($interface in $interfaces) {
+	foreach ($method in $interface.GetMethods()) {
+		$httpAttributes = @($method.GetCustomAttributes($true) | Where-Object { $_.GetType().FullName -like 'Refit.*' -and ($_.PSObject.Properties.Name -contains 'Path') })
+		if ($httpAttributes.Count -eq 0) { continue }
+		$endpoints.Add([PSCustomObject]@{
+				Verb       = "$($httpAttributes[0].Method)".ToLowerInvariant()
+				Path       = $httpAttributes[0].Path
+				ReturnType = $method.ReturnType
+				Interface  = $interface.Name
+				MethodName = $method.Name
+			})
+	}
+}
+
+$spec = Get-Content -LiteralPath $specPath -Raw | ConvertFrom-Json -Depth 100
+$specOperations = @{}
+foreach ($pathProperty in $spec.paths.PSObject.Properties) {
+	$normalized = Get-NormalizedPath -Path $pathProperty.Name
+	foreach ($verbProperty in $pathProperty.Value.PSObject.Properties) {
+		$verb = $verbProperty.Name.ToLowerInvariant()
+		if ($verb -notin @('get', 'post', 'put', 'delete')) { continue }
+		$specOperations["$verb $normalized"] = $verbProperty.Value
+	}
+}
+
+# ---- Checks ------------------------------------------------------------------------------------
+$script:findings = [System.Collections.Generic.List[object]]::new()
+$script:visited = [System.Collections.Generic.HashSet[string]]::new()
+
+function Add-Finding {
+	param([string]$Kind, [string]$ClrType, [string]$Detail, [string]$OperationId, [string]$Method, [string]$Suggestion)
+	$script:findings.Add([PSCustomObject]@{
+			Kind        = $Kind
+			ClrType     = $ClrType
+			Detail      = $Detail
+			Suggestion  = $Suggestion
+			OperationId = $OperationId
+			Method      = $Method
+		})
+}
+
+function Find-Typos {
+	param($Schema, [Type]$ClrType, [int]$Depth, [string]$OperationId, [string]$Method)
+
+	if ($Depth -gt 8 -or $null -eq $Schema -or $null -eq $ClrType) { return }
+	$Schema = Resolve-Schema -Schema $Schema
+	$kind = Get-SchemaKind -Schema $Schema
+
+	if ($kind -eq 'array') {
+		$element = Get-ElementType -Type $ClrType
+		if ($null -eq $element) { $element = $ClrType }
+		if ($Schema.PSObject.Properties.Name -contains 'items') { Find-Typos -Schema $Schema.items -ClrType $element -Depth ($Depth + 1) -OperationId $OperationId -Method $Method }
+		return
+	}
+	if ($kind -ne 'object' -or $Schema.PSObject.Properties.Name -notcontains 'properties' -or $null -eq $Schema.properties) { return }
+
+	$underlying = [Nullable]::GetUnderlyingType($ClrType)
+	if ($underlying) { $ClrType = $underlying }
+	$element = Get-ElementType -Type $ClrType
+	if ($element) { $ClrType = $element }
+	if (Test-OpaqueType -Type $ClrType) { return }
+	if (-not $script:visited.Add("$($ClrType.FullName)|$OperationId")) { return }
+
+	$members = Get-JsonMemberMap -Type $ClrType
+	$specNames = @($Schema.properties.PSObject.Properties.Name)
+	$unmappedSpecNames = @($specNames | Where-Object { -not $members.Contains($_) })
+
+	foreach ($entry in $members.GetEnumerator()) {
+		$clrJsonName = $entry.Key
+		if ($specNames -contains $clrJsonName) {
+			Find-Typos -Schema $Schema.properties.$clrJsonName -ClrType $entry.Value.Type -Depth ($Depth + 1) -OperationId $OperationId -Method $Method
+			continue
+		}
+		# Absent from the spec. Only interesting if it is a near miss of a spec name nothing else claims.
+		foreach ($candidate in $unmappedSpecNames) {
+			$distance = Get-EditDistance -A $clrJsonName -B $candidate
+			if ($distance -gt 0 -and $distance -le $MaxEditDistance) {
+				Add-Finding -Kind 'LikelyTypo' -ClrType $ClrType.Name -Detail "[DataMember(Name = `"$clrJsonName`")] on $($entry.Value.Property)" -Suggestion "spec has `"$candidate`" (edit distance $distance)" -OperationId $OperationId -Method $Method
+			}
+		}
+	}
+}
+
+$matched = 0
+foreach ($endpoint in $endpoints) {
+	$key = "$($endpoint.Verb) $(Get-NormalizedPath -Path $endpoint.Path)"
+	if (-not $specOperations.ContainsKey($key)) { continue }
+	$matched++
+	$operation = $specOperations[$key]
+	$operationId = if ($operation.PSObject.Properties.Name -contains 'operationId') { "$($operation.operationId)" } else { $key }
+	$methodLabel = "$($endpoint.Interface).$($endpoint.MethodName)"
+
+	if ($operation.PSObject.Properties.Name -notcontains 'responses') { continue }
+	$successName = @($operation.responses.PSObject.Properties.Name | Where-Object { $_ -match '^2' }) | Select-Object -First 1
+	if (-not $successName) { continue }
+	$success = $operation.responses.$successName
+	$hasBody = ($success.PSObject.Properties.Name -contains 'content')
+	$payloadType = Get-PayloadType -Type $endpoint.ReturnType
+	$returnsPayload = -not (Test-OpaqueType -Type $payloadType) -or ($payloadType.FullName -notin @('System.Threading.Tasks.Task', 'System.Void'))
+
+	if (-not $hasBody) {
+		if ($payloadType.FullName -notin @('System.Threading.Tasks.Task', 'System.Void') -and $payloadType.Name -notin @('HttpResponseMessage', 'IApiResponse')) {
+			Add-Finding -Kind 'BodyExpectedButSpecHasNone' -ClrType $payloadType.Name -Detail "returns $($payloadType.Name) but the spec's $successName has no body" -Suggestion 'consider returning Task' -OperationId $operationId -Method $methodLabel
+		}
+		continue
+	}
+
+	$jsonContent = $success.content.PSObject.Properties | Where-Object { $_.Name -like 'application/json*' } | Select-Object -First 1
+	if (-not $jsonContent -or ($jsonContent.Value.PSObject.Properties.Name -notcontains 'schema')) { continue }
+	$schema = Resolve-Schema -Schema $jsonContent.Value.schema
+	$specKind = Get-SchemaKind -Schema $schema
+
+	if ($payloadType.FullName -in @('System.Threading.Tasks.Task', 'System.Void')) {
+		Add-Finding -Kind 'BodyDiscarded' -ClrType '(none)' -Detail "returns Task but the spec's $successName carries a $specKind body" -Suggestion 'consider returning the payload' -OperationId $operationId -Method $methodLabel
+		continue
+	}
+
+	$clrIsCollection = $null -ne (Get-ElementType -Type $payloadType)
+	$clrIsDictionary = Test-DictionaryType -Type $payloadType
+	$specKeys = if ($specKind -eq 'object' -and ($schema.PSObject.Properties.Name -contains 'properties') -and $schema.properties) { @($schema.properties.PSObject.Properties.Name) } else { @() }
+	$isWrapper = ($specKind -eq 'object') -and ($specKeys -contains 'items')
+
+	if ($specKind -eq 'array' -and -not $clrIsCollection -and -not $clrIsDictionary) {
+		Add-Finding -Kind 'ShapeMismatch' -ClrType $payloadType.Name -Detail "spec returns an array, method returns a single $($payloadType.Name)" -Suggestion "List<$($payloadType.Name)>" -OperationId $operationId -Method $methodLabel
+	}
+	elseif ($specKind -eq 'object' -and $clrIsCollection) {
+		$suggestion = if ($isWrapper) { "a wrapper type with Items and Meta" } else { "a single object" }
+		$shape = if ($isWrapper) { "an {$($specKeys -join ', ')} wrapper" } else { "an object" }
+		Add-Finding -Kind 'ShapeMismatch' -ClrType $payloadType.Name -Detail "spec returns $shape, method returns $($payloadType.Name)" -Suggestion $suggestion -OperationId $operationId -Method $methodLabel
+	}
+	elseif ($isWrapper -and -not $clrIsCollection) {
+		# Object into object: only a mismatch if the CLR type has no 'items' member itself.
+		$members = Get-JsonMemberMap -Type $payloadType
+		if (-not $members.Contains('items')) {
+			Add-Finding -Kind 'ShapeMismatch' -ClrType $payloadType.Name -Detail "spec returns an {$($specKeys -join ', ')} wrapper, $($payloadType.Name) has no 'items' member" -Suggestion "a wrapper type with Items and Meta" -OperationId $operationId -Method $methodLabel
+		}
+	}
+
+	Find-Typos -Schema $schema -ClrType $payloadType -Depth 0 -OperationId $operationId -Method $methodLabel
+}
+
+Write-Information "Endpoints matched to a spec operation: $matched"
+$byKind = $script:findings | Group-Object Kind | ForEach-Object { "$($_.Name)=$($_.Count)" }
+Write-Information "Findings: $($script:findings.Count) ($($byKind -join ', '))"
+
+$sorted = $script:findings | Sort-Object Kind, ClrType, Method
+if ($OutCsv) {
+	$sorted | Export-Csv -LiteralPath $OutCsv -NoTypeInformation -Encoding UTF8
+	Write-Information "Wrote $OutCsv"
+}
+return $sorted

--- a/.github/skills/meraki-api-update/SKILL.md
+++ b/.github/skills/meraki-api-update/SKILL.md
@@ -42,9 +42,25 @@ first using `-Latest`, then continue after confirmation.
    - `changelog.md`
    - `spec3.json`
    - `metadata.json`
-4. Compare the changelog and OpenAPI schemas against the existing codebase.
+4. Compare the changelog and OpenAPI schemas against the existing codebase. For
+   missing model members, do not read the changelog narratively - build the
+   repository and run the diff, which reflects over the compiled interfaces and
+   walks every 2xx response schema against the return types:
+
+```powershell
+dotnet build Meraki.Api.slnx -c Debug
+pwsh -File .\.github\skills\meraki-api-update\Find-MissingModelMembers.ps1 -SpecVersion v1.74.0 -OutCsv gap.csv
+```
+
+   It also reports how many spec operations are unimplemented and how many
+   library endpoints match no spec path.
+
 5. Implement feasible missing model members and other directly supported code
    changes.
+
+   Note that a full run typically finds more members than one release
+   introduced, because the gap accumulates. Agree the split into pull requests
+   with the requester before implementing; per product area works well.
 6. Identify missing endpoints, section wiring, request/response models, or other
    follow-up work that should be implemented.
 7. Update `CHANGELOG.md` with the changes made in the repository.
@@ -103,10 +119,15 @@ Always note when you find additional work that is not completed, such as:
 ## Helper Assets
 
 - `.github/skills/meraki-api-update/Prepare-MerakiApiUpdate.ps1`
+- `.github/skills/meraki-api-update/Find-MissingModelMembers.ps1`
+- `.github/skills/meraki-api-update/gap-report-v1.74.0.md`
 - `.github/tools/Add-XmlDocumentation.ps1`
 
 The preparation script fetches the versioned source documents into the ignored
-`tmp` folder. The XML documentation helper can be used after model and interface
+`tmp` folder. The diff script needs the solution built first, because it
+reflects over the compiled assembly. The gap report is the checked-in output of
+a full run, useful as a starting point and for seeing what has since been
+closed. The XML documentation helper can be used after model and interface
 updates if new public members need doc comments.
 
 ## Validation

--- a/.github/skills/meraki-api-update/gap-report-v1.74.0.md
+++ b/.github/skills/meraki-api-update/gap-report-v1.74.0.md
@@ -31,6 +31,85 @@ They need their own pass; a few may be dead code.
 This is the accumulated gap, not only what 1.71 to 1.74 introduced. No attempt was made to
 attribute each member to the release that added it.
 
+## Shape and spelling defects
+
+Produced by `Find-ModelShapeMismatches.ps1`. These are not missing members: the model disagrees with
+the spec in a way that stops the response binding at all. Object-versus-`List` findings need a check
+against an observed response, because the Meraki spec sometimes documents a list endpoint's item
+rather than the array (`getNetworkWirelessRfProfiles` is one; live responses are arrays).
+
+### Return type is a `List` but the spec returns an `{items, meta}` wrapper (cannot deserialize)
+
+| Method | Spec shape |
+|---|---|
+| `IOrganizationsNetworks.GetNetworkMovesAsync` | `{items, meta}` |
+| `IOrganizationsCampusGatewayClusters.GetOrganizationCampusGatewayClustersAsync` | `{items, meta}` |
+| `IOrganizationSensorGatewaysConnectionsLatest.GetOrganizationSensorGatewaysConnectionsLatestAsync` | `{items, meta}` |
+| `IOrganizationsIntegrationsXdr.GetOrganizationIntegrationsXdrNetworksAsync` | `{items, meta}` |
+| `IOrganizationSwitches.GetOrganizationSwitchPortsStatusesBySwitchAsync` | `{items, meta}` |
+| `IOrganizationsSmSentry.UpdateOrganizationSmSentryPoliciesAssignments` | `{items}`; response type has no `items` member |
+
+### Return type is a single object but the spec returns an array (cannot deserialize)
+
+| Method | Returns |
+|---|---|
+| `IAdministeredLicensingSubscriptionSubscriptionsCompliance.GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesAsync` | `AdministeredLicensingSubscriptionSubscriptionsComplianceStatuses` |
+| `ISmDevicesConnectivity.GetNetworkSmDeviceConnectivityAsync` | `DeviceConnectivity` |
+| `ICellularGatewayEsims.GetOrganizationCellularGatewayEsimsServiceProvidersAccountsAsync` | `EsimsServiceProvidersAccounts` |
+| `IOrganizationsFloorPlansAutoLocate.GetOrganizationFloorPlansAutoLocateDevicesAsync` | `FloorPlansAutoLocateDevices` |
+| `IOrganizationsFloorPlansAutoLocate.GetOrganizationFloorPlansAutoLocateStatusesAsync` | `FloorPlansAutoLocateStatuses` |
+| `INetworksFirmwareUpgrades.UpdateNetworkFirmwareUpgradesStagedStagesAsync` | `NetworkFirmwareUpgradesStagedStage` |
+| `IOrganizationsApplianceDnsLocalRecord.CreateOrganizationApplianceDnsLocalRecordAsync` | `OrganizationApplianceDnsLocalRecordsResponse` |
+| `IOrganizationsApplianceDnsLocalRecord.GetOrganizationApplianceDnsLocalRecordsAsync` | `OrganizationApplianceDnsLocalRecordsResponse` |
+| `IOrganizationsDevicesController.CreateOrganizationDevicesControllerMigrationAsync` | `OrganizationsDevicesControllerMigration` |
+| `IOrganizationsSmSentry.GetOrganizationSmSentryPoliciesAssignmentsByNetwork` | `OrganizationSmSentryPoliciesAssignmentsByNetworkResponse` |
+| `IOrganizationsWirelessRadsecCertificates.GetOrganizationWirelessDevicesRadsecCertificatesAuthoritiesAsync` | `OrganizationWirelessDevicesRadsecCertificatesAuthorities` |
+
+### Return type is a `List` but the spec returns a single object
+
+Single-resource paths (`/{service}`, `/{deviceId}/restrictions`, `/customAnalytics`, a create) are
+almost certainly real; the three list-shaped paths at the bottom are probably the spec quirk.
+
+| Method | Spec keys | Assessment |
+|---|---|---|
+| `IApplianceFirewallFirewalledServices.GetNetworkApplianceFirewallFirewalledServiceAsync` | `access, allowedIps, service` | real |
+| `IApplianceFirewallFirewalledServices.UpdateNetworkApplianceFirewallFirewalledServiceAsync` | `access, allowedIps, service` | real |
+| `IApplianceFirewallInboundCellularFirewallRules.GetNetworkApplianceFirewallInboundCellularFirewallRulesAsync` | `rules` | real |
+| `IApplianceFirewallInboundCellularFirewallRules.UpdateNetworkApplianceFirewallInboundCellularFirewallRulesAsync` | `rules` | real |
+| `IApplianceSdwanInternetPolicies.UpdateNetworkApplianceSdwanInternetPoliciesAsync` | `wanTrafficUplinkPreferences` | real |
+| `ICameraCustomAnalytics.GetDeviceCameraCustomAnalyticsAsync` | `artifactId, enabled, parameters` | real |
+| `ICameraCustomAnalytics.UpdateDeviceCameraCustomAnalyticsAsync` | `artifactId, enabled, parameters` | real |
+| `IOrganizationsAdaptivePolicyAcls.CreateOrganizationAdaptivePolicyAclAsync` | `aclId, createdAt, ...` | real |
+| `IOrganizationSensorRelationships.GetDeviceSensorRelationshipsAsync` | `livestream` | real |
+| `ISmDevicesRestrictions.GetNetworkSmDeviceRestrictionsAsync` | `restrictions` | real |
+| `IAdministeredLicensingSubscriptionEntitlements.GetAdministeredLicensingSubscriptionEntitlementsAsync` | item fields | probably spec quirk |
+| `IOrganizationsEarlyAccessFeatures.GetOrganizationEarlyAccessFeaturesOptInsAsync` | item fields | probably spec quirk |
+| `IWirelessRfProfiles.GetNetworkWirelessRfProfilesAsync` | item fields | spec quirk, observed as array |
+
+### Misspelt `[DataMember]` names (property has never bound)
+
+| Model | Has | Spec has |
+|---|---|---|
+| `NetworkMoveDetailed` | `intiator` | `initiator` |
+| `ConnectivityEvents` | `occuredAt` | `occurredAt` |
+| `OrganizationLicensingCotermLicenseMoveResponse` | `moveLicenses` | `movedLicenses` |
+| `OrganizationSplashTheme` | `themeAssests` | `themeAssets` |
+| `SensorAlertConditionThresholdTemperature` | `farenheit` | `fahrenheit` |
+| `NetworksCampusGatewayClusterUplink` | `address` (property `Addresses`) | `addresses` (array) |
+| `NetworkFirmwareUpgrade` | `products` | `product` - needs a look |
+
+Dismissed as false positives: `eco2` vs `no2` (both exist), `OrganizationAssuranceAlertsOverviewByTypeItem.networkId` vs `networks`, and `SmDevicesCheckinRequest` plurals (they match the request body).
+
+### Stale model
+
+`NetworkMove` (the `createNetworkMove` 201) has `networkMoveId` and `url`; the spec returns
+`createdAt, initiator, lastUpdatedAt, moveId, network, organizations, result`. Neither existing
+property is in the spec, so the whole response is unmapped. `NetworkMoveDetailed` is missing
+`moveId` and `result`, and its `status` is no longer in the spec.
+
+Also reported: 6 methods return `Task` while the spec documents a response body, and 1 returns a
+type where the spec's 2xx has no body. See the script output for the list.
+
 ## Unmapped members by product area
 
 | Area | Members | Of which object or array |

--- a/.github/skills/meraki-api-update/gap-report-v1.74.0.md
+++ b/.github/skills/meraki-api-update/gap-report-v1.74.0.md
@@ -1,0 +1,260 @@
+# Meraki.Api against Dashboard API v1.74.0
+
+Produced by `Find-MissingModelMembers.ps1` on 2026-09-09, against `main` at 84a0c39b.
+Regenerate with:
+
+```powershell
+pwsh -File .\.github\skills\meraki-api-update\Prepare-MerakiApiUpdate.ps1 -Version 1.74.0
+dotnet build Meraki.Api.slnx -c Debug
+pwsh -File .\.github\skills\meraki-api-update\Find-MissingModelMembers.ps1 -SpecVersion v1.74.0 -OutCsv gap.csv
+```
+
+## Coverage
+
+| Measure | Count |
+|---|---|
+| Refit endpoints in the library | 1075 |
+| Operations in the v1.74.0 spec | 998 |
+| Library endpoints matched to a spec operation | 861 |
+| Library endpoints with no spec match | 214 |
+| Spec operations not implemented | 140 |
+| Unmapped response members on existing models | 155, across 86 types |
+
+The 155 unmapped members break down as 118 scalars (string, integer, boolean, number) and 37
+objects plus 23 arrays, so around 57 new nested model classes are needed alongside the
+properties themselves.
+
+The 214 unmatched library endpoints are not necessarily wrong. Some will be endpoints Cisco has
+removed or renamed, and some will be path shapes this script's normalisation does not line up.
+They need their own pass; a few may be dead code.
+
+This is the accumulated gap, not only what 1.71 to 1.74 introduced. No attempt was made to
+attribute each member to the release that added it.
+
+## Unmapped members by product area
+
+| Area | Members | Of which object or array |
+|---|---|---|
+| Organizations | 43 | 22 |
+| SM | 27 | 5 |
+| Appliance | 21 | 12 |
+| Wireless | 19 | 6 |
+| Switch | 11 | 3 |
+| General | 10 | 1 |
+| Camera | 8 | 1 |
+| CellularGateway | 7 | 1 |
+| Sensor | 6 | 5 |
+| LiveTools | 2 | 0 |
+| Licensing | 1 | 1 |
+
+## Unmapped members in full
+
+### Appliance (21)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `AppliancePort` | `sgt` | object | getNetworkAppliancePort, getNetworkAppliancePorts |
+| `Gre` | `clientIsolation` | boolean | getNetworkWirelessSsid, getNetworkWirelessSsids |
+| `LanConfiguration` | `vrf` | object | getNetworkApplianceSingleLan |
+| `MxFirewallRule` | `rules` | array | getNetworkApplianceFirewallInboundCellularFirewallRules |
+| `Neighbor` | `vrf` | object | getNetworkApplianceVpnBgp |
+| `NetworkUmbrellaAccountConnectResponse` | `umbrella` | object | connectNetworkApplianceUmbrellaAccount |
+| `OrganizationApplianceDnsLocalRecordsProfile` | `address` | string | updateOrganizationApplianceDnsLocalRecord |
+| `OrganizationApplianceDnsLocalRecordsProfile` | `hostname` | string | updateOrganizationApplianceDnsLocalRecord |
+| `OrganizationApplianceDnsLocalRecordsProfile` | `profile` | object | updateOrganizationApplianceDnsLocalRecord |
+| `OrganizationApplianceDnsLocalRecordsProfile` | `recordId` | string | updateOrganizationApplianceDnsLocalRecord |
+| `SecurityEvent` | `wanTrafficUplinkPreferences` | array | updateNetworkApplianceSdwanInternetPolicies |
+| `SiteToSiteVpn` | `hostTranslations` | array | getNetworkApplianceVpnSiteToSiteVpn |
+| `SiteToSiteVpn` | `sgt` | object | getNetworkApplianceVpnSiteToSiteVpn |
+| `StaticRoute` | `ipVersion` | integer | getNetworkApplianceStaticRoute, getNetworkApplianceStaticRoutes |
+| `ThirdPartyVpnPeer` | `ecmpUplinkConfigs` | array | getOrganizationApplianceVpnThirdPartyVPNPeers |
+| `ThirdPartyVpnPeerEbgpNeighbor` | `receiveLimit` | integer | getOrganizationApplianceVpnThirdPartyVPNPeers |
+| `ThirdPartyVpnPeers` | `name` | string | getOrganizationApplianceVpnStatuses |
+| `ThirdPartyVpnPeers` | `publicIp` | string | getOrganizationApplianceVpnStatuses |
+| `ThirdPartyVpnPeers` | `reachability` | string | getOrganizationApplianceVpnStatuses |
+| `TrafficUplinkPreference` | `vrf` | object | getNetworkApplianceTrafficShapingUplinkSelection |
+| `Vlan` | `sgt` | object | createNetworkApplianceVlan, getNetworkApplianceVlans |
+
+### Camera (8)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `CameraRoleAppliedOnDevice` | `permissionLevel` | string | createOrganizationCameraRole, getOrganizationCameraRoles |
+| `CameraRoleAppliedOnDevice` | `permissionScope` | string | createOrganizationCameraRole, getOrganizationCameraRoles |
+| `CameraRoleAppliedOnNetwork` | `permissionLevel` | string | createOrganizationCameraRole, getOrganizationCameraRoles |
+| `CameraRoleAppliedOnNetwork` | `permissionScope` | string | createOrganizationCameraRole, getOrganizationCameraRoles |
+| `CameraRoleAppliedOrgWide` | `permissionLevel` | string | createOrganizationCameraRole, getOrganizationCameraRoles |
+| `CameraRoleAppliedOrgWide` | `permissionScope` | string | createOrganizationCameraRole, getOrganizationCameraRoles |
+| `CameraRoleAppliedOrgWide` | `tag` | string | createOrganizationCameraRole, getOrganizationCameraRoles |
+| `Zones` | `zoneId` | object | getDeviceCameraAnalyticsLive |
+
+### CellularGateway (7)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `EsimsServiceProvidersAccountsItem` | `accountId` | string | getOrganizationCellularGatewayEsimsServiceProvidersAccounts |
+| `EsimsServiceProvidersAccountsItem` | `lastUpdatedAt` | string | getOrganizationCellularGatewayEsimsServiceProvidersAccounts |
+| `EsimsServiceProvidersAccountsItem` | `serviceProvider` | object | getOrganizationCellularGatewayEsimsServiceProvidersAccounts |
+| `EsimsServiceProvidersAccountsItem` | `title` | string | getOrganizationCellularGatewayEsimsServiceProvidersAccounts |
+| `EsimsServiceProvidersAccountsItem` | `username` | string | getOrganizationCellularGatewayEsimsServiceProvidersAccounts |
+| `EsimsServiceProvidersItemLogo` | `url` | string | getOrganizationCellularGatewayEsimsServiceProviders |
+| `NetworkCellularGatewayEsimsInventoryItemDevice` | `status` | string | getOrganizationCellularGatewayEsimsInventory, updateOrganizationCellularGatewayEsimsInventory |
+
+### General (10)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `Client` | `cdp` | array | getNetworkClient |
+| `ClientProvision` | `clientId` | string | provisionNetworkClients |
+| `ClientProvision` | `message` | string | provisionNetworkClients |
+| `DeviceClient` | `adaptivePolicyGroup` | string | getDeviceClients |
+| `DeviceClient` | `switchport` | string | getDeviceClients |
+| `Events` | `clientMac` | string | getNetworkEvents |
+| `LossAndLatencyHistory` | `endTime` | string | getDeviceLossAndLatencyHistory |
+| `LossAndLatencyHistory` | `startTime` | string | getDeviceLossAndLatencyHistory |
+| `SubclassApplicationUsage` | `received` | integer | getNetworkClientsApplicationUsage |
+| `SubclassUsageHistory` | `received` | number | getNetworkClientsUsageHistories |
+
+### Licensing (1)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `OrganizationLicensingCotermLicenseMoveResponse` | `movedLicenses` | array | moveOrganizationLicensingCotermLicenses |
+
+### LiveTools (2)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `LiveToolsArpTableResultTableEntry` | `interface` | string | getDeviceLiveToolsArpTable |
+| `LiveToolsThroughputTestCreateResponse` | `throughputTestId` | string | createDeviceLiveToolsThroughputTest |
+
+### Organizations (43)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `EarlyAccessFeatureOptInOptOutEligibilityHelp` | `label` | string | createOrganizationEarlyAccessFeaturesOptIn, getOrganizationEarlyAccessFeaturesOptIns |
+| `FirmwareProducts` | `campusGateway` | object | getNetworkFirmwareUpgrades |
+| `LoginSecurity` | `enforceLockedIpSessions` | boolean | getOrganizationLoginSecurity |
+| `NetworkFirmwareUpdateStagedEventsProducts` | `switchCatalyst` | object | deferNetworkFirmwareUpgradesStagedEvents, rollbacksNetworkFirmwareUpgradesStagedEvents |
+| `NetworkFirmwareUpgradeStagedEventsProduct` | `switchCatalyst` | object | getNetworkFirmwareUpgradesStagedEvents |
+| `NetworkMove` | `createdAt` | string | createNetworkMove |
+| `NetworkMove` | `initiator` | object | createNetworkMove |
+| `NetworkMove` | `lastUpdatedAt` | string | createNetworkMove |
+| `NetworkMove` | `moveId` | string | createNetworkMove |
+| `NetworkMove` | `network` | object | createNetworkMove |
+| `NetworkMove` | `organizations` | object | createNetworkMove |
+| `NetworkMove` | `result` | object | createNetworkMove |
+| `NetworkMoveDetailed` | `items` | array | getNetworkMoves |
+| `NetworkMoveDetailed` | `meta` | object | getNetworkMoves |
+| `NetworksCampusGatewayClusterUplink` | `addresses` | array | createNetworkCampusGatewayCluster |
+| `NetworkStatusSummary` | `group` | object | getOrganizationSummaryTopNetworksByStatus |
+| `NetworkStatusSummary` | `permissions` | object | getOrganizationSummaryTopNetworksByStatus |
+| `NextUpgrade` | `predownload` | object | getNetworkFirmwareUpgrades |
+| `NextUpgrade` | `strategy` | string | getNetworkFirmwareUpgrades |
+| `OrganizationAdaptivePolicyOverview` | `limits` | object | getOrganizationAdaptivePolicyOverview |
+| `OrganizationAdaptivePolicyOverviewCounts` | `customGroups` | integer | getOrganizationAdaptivePolicyOverview |
+| `OrganizationAdaptivePolicyOverviewCounts` | `policyObjects` | integer | getOrganizationAdaptivePolicyOverview |
+| `OrganizationAssuranceAlertScopeDevice` | `productType` | string | getOrganizationAssuranceAlert, getOrganizationAssuranceAlerts |
+| `OrganizationAssuranceAlertsOverviewByNetworkItem` | `lastAlertedAt` | string | getOrganizationAssuranceAlertsOverviewByNetwork |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `categoryType` | string | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `count` | integer | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `deviceTags` | array | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `deviceTypes` | array | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `lastAlertedAt` | string | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `lastResolvedAt` | string | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `networkCount` | integer | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `networks` | array | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `severity` | string | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationAssuranceAlertsOverviewByTypeItem` | `type` | string | getOrganizationAssuranceAlertsOverviewByType |
+| `OrganizationCampusGatewayCluster` | `items` | array | getOrganizationCampusGatewayClusters |
+| `OrganizationCampusGatewayCluster` | `meta` | object | getOrganizationCampusGatewayClusters |
+| `OrganizationDevice` | `imei` | string | getOrganizationDevices |
+| `OrganizationDevicesSyslogServersRolesByNetworkItem` | `available` | array | getOrganizationDevicesSyslogServersRolesByNetwork |
+| `OrganizationSplashTheme` | `isSystemTheme` | boolean | createOrganizationSplashTheme, getOrganizationSplashThemes |
+| `OrganizationSplashTheme` | `themeAssets` | array | createOrganizationSplashTheme, getOrganizationSplashThemes |
+| `SamlIdp` | `ssoLoginUrl` | string | getOrganizationSamlIdp, getOrganizationSamlIdps |
+| `SamlIdp` | `visionConsumerUrl` | string | getOrganizationSamlIdp, getOrganizationSamlIdps |
+| `WebhookAlertType` | `example` | object | getOrganizationWebhooksAlertTypes |
+
+### Sensor (6)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `SensorAlertConditionThresholdTemperature` | `fahrenheit` | number | getNetworkSensorAlertsProfile, getNetworkSensorAlertsProfiles |
+| `SensorReadingHistoric` | `no2` | object | getOrganizationSensorReadingsHistory |
+| `SensorReadingHistoric` | `o3` | object | getOrganizationSensorReadingsHistory |
+| `SensorReadingHistoric` | `pm10` | object | getOrganizationSensorReadingsHistory |
+| `SensorReadingLatest` | `items` | array | getOrganizationSensorGatewaysConnectionsLatest |
+| `SensorReadingLatest` | `meta` | object | getOrganizationSensorGatewaysConnectionsLatest |
+
+### SM (27)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `DeviceLiveToolsMacTableCreateResponseRequest` | `mac` | string | createDeviceLiveToolsMacTable |
+| `DeviceLiveToolsMacTableGetResponseRequest` | `mac` | string | getDeviceLiveToolsMacTable |
+| `DeviceLiveToolsMulticastRoutingGetResponseInterface` | `ipVersion` | string | getDeviceLiveToolsMulticastRouting |
+| `DeviceLiveToolsMulticastRoutingGetResponseInterface` | `vrf` | string | getDeviceLiveToolsMulticastRouting |
+| `DeviceLiveToolsMulticastRoutingGetResponseInterface` | `vrfType` | string | getDeviceLiveToolsMulticastRouting |
+| `DeviceLiveToolsMulticastRoutingGetResponseRoute` | `ipVersion` | string | getDeviceLiveToolsMulticastRouting |
+| `DeviceLiveToolsMulticastRoutingGetResponseRoute` | `vrf` | string | getDeviceLiveToolsMulticastRouting |
+| `OrganizationSmSentryPoliciesAssignmentsResponse` | `items` | array | updateOrganizationSmSentryPoliciesAssignments |
+| `SmDevicesCheckinRequest` | `id` | string | modifyNetworkSmDevicesTags |
+| `SmDevicesCheckinRequest` | `serial` | string | modifyNetworkSmDevicesTags |
+| `SmDevicesCheckinRequest` | `tags` | array | modifyNetworkSmDevicesTags |
+| `SmDevicesCheckinRequest` | `wifiMac` | string | modifyNetworkSmDevicesTags |
+| `SmProfile` | `payloadTypes` | array | getNetworkSmProfiles |
+| `SmTrustedAccessConfig` | `timeboundType` | string | getNetworkSmTrustedAccessConfigs |
+| `SmVppAccount` | `allowedAdmins` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `assignableNetworkIds` | array | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `assignableNetworks` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `contentToken` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `email` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `lastForceSyncedAt` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `lastSyncedAt` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `name` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `networkIdAdmins` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `parsedToken` | object | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `vppAccountId` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `vppLocationId` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+| `SmVppAccount` | `vppLocationName` | string | getOrganizationSmVppAccount, getOrganizationSmVppAccounts |
+
+### Switch (11)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `AlternateManagementInterface` | `useOobMgmt` | boolean | getNetworkSwitchAlternateManagementInterface |
+| `ConfigOverrides` | `voiceVlan` | integer | getDeviceSwitchPortsStatuses |
+| `ConfigTemplateSwitchProfilePort` | `stpPortFastTrunk` | boolean | getOrganizationConfigTemplateSwitchProfilePort, getOrganizationConfigTemplateSwitchProfilePorts |
+| `ConfigTemplateSwitchProfilePortDot3az` | `enabled` | boolean | getOrganizationConfigTemplateSwitchProfilePort, getOrganizationConfigTemplateSwitchProfilePorts |
+| `NetworksSwitchDhcpV4ServersSeenLastPacketSourceIpv4` | `address` | string | getNetworkSwitchDhcpV4ServersSeen |
+| `StackDevice` | `productType` | string | getNetworkTopologyLinkLayer |
+| `SwitchPort` | `stpPortFastTrunk` | boolean | getDeviceSwitchPort, getDeviceSwitchPorts |
+| `SwitchPortsStatusesBySwitch` | `items` | array | getOrganizationSwitchPortsStatusesBySwitch |
+| `SwitchPortsStatusesBySwitch` | `meta` | object | getOrganizationSwitchPortsStatusesBySwitch |
+| `SwitchPortsTopologyDiscoveryByDeviceItemPort` | `intervals` | array | getOrganizationSwitchPortsUsageHistoryByDeviceByInterval |
+| `SwitchPortsUsageHistoryByDeviceByIntervalItem` | `serial` | string | getOrganizationSwitchPortsUsageHistoryByDeviceByInterval |
+
+### Wireless (19)
+
+| Model | JSON member | JSON type | Seen in |
+|---|---|---|---|
+| `AirMarshal` | `encryption` | string | getNetworkWirelessAirMarshal |
+| `AirMarshal` | `manufacturers` | array | getNetworkWirelessAirMarshal |
+| `AirMarshal` | `types` | array | getNetworkWirelessAirMarshal |
+| `ConnectivityEvents` | `occurredAt` | string | getNetworkWirelessClientConnectivityEvents |
+| `ConnectivityEvents` | `ssidNumber` | integer | getNetworkWirelessClientConnectivityEvents |
+| `DevicesWirelessZigbeeEnrollmentsDetailed` | `enrollmentStartedAt` | string | getDeviceWirelessZigbeeEnrollment |
+| `ElectronicShelfLabelSettingsNetwork` | `sepioo` | object | getNetworkWirelessElectronicShelfLabel, getNetworkWirelessElectronicShelfLabelConfiguredDevices |
+| `FailedConnection` | `radio` | integer | getNetworkWirelessFailedConnections |
+| `NaiRealm` | `name` | string | getNetworkWirelessSsidHotspot20 |
+| `OrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalGetResponse` | `meta` | object | getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval |
+| `Ssid` | `campusGateway` | object | getNetworkWirelessSsid, getNetworkWirelessSsids |
+| `Ssid` | `wlanIdentifier` | integer | getNetworkWirelessSsid, getNetworkWirelessSsids |
+| `SsidsStatusesByDeviceItemBasicServiceSetRadio` | `index` | string | getOrganizationWirelessSsidsStatusesByDevice |
+| `Wifi` | `endTime` | string | getNetworkNetworkHealthChannelUtilization |
+| `Wifi` | `startTime` | string | getNetworkNetworkHealthChannelUtilization |
+| `Wifi` | `utilization80211` | number | getNetworkNetworkHealthChannelUtilization |
+| `Wifi` | `utilizationNon80211` | number | getNetworkNetworkHealthChannelUtilization |
+| `Wifi` | `utilizationTotal` | number | getNetworkNetworkHealthChannelUtilization |
+| `WirelessRfProfile` | `dot11be` | object | createNetworkWirelessRfProfile, getNetworkWirelessRfProfiles |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## 1.74.2
+## 1.74.5
 
 - **The library now tracks Dashboard API 1.74**, so `version.json` moves from `1.70` to `1.74`.
   v1.74.0 is the latest stable tag in `meraki/openapi`, published 2026-09-02. This resets the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ﻿# Changelog
 
+## 1.74.2
+
+- **The library now tracks Dashboard API 1.74**, so `version.json` moves from `1.70` to `1.74`.
+  v1.74.0 is the latest stable tag in `meraki/openapi`, published 2026-09-02. This resets the
+  Nerdbank.GitVersioning height, which is why the versions jump from 1.70.138 rather than
+  continuing to 1.70.139.
+
+  The bump says which spec version the library is measured against. It does **not** claim every
+  1.74 endpoint is implemented, and **no library code changed in this release** — only
+  `version.json` and the repository's own tooling.
+
+- **A repeatable model gap diff**, `.github/skills/meraki-api-update/Find-MissingModelMembers.ps1`.
+  It reflects over the compiled Refit interfaces, matches each method's verb and path to a spec
+  operation, then walks every 2xx JSON response schema in parallel with the C# return type,
+  comparing spec property names against `[DataMember]` names. Dictionary-typed models, non-generic
+  `Task` returns and purely numeric property names are excluded, because the spec describes those
+  as ordinary properties while the models correctly represent them as open-ended maps or as no
+  payload at all.
+
+  Against v1.74.0 it reports **155 unmapped response members across 86 types**, 140 spec operations
+  not implemented, and 214 library endpoints matching no spec path. That run is checked in as
+  `gap-report-v1.74.0.md`, broken down by product area. This is the accumulated gap, not only what
+  1.71 to 1.74 introduced.
+
 ## 1.70.138
 
 - **Fourteen more response fields the Dashboard API returns are now mapped.** An unmapped-member

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.70",
+  "version": "1.74",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/tags/\\d\u002B\\.\\d\u002B\\.\\d\u002B",


### PR DESCRIPTION
## What

Two things, no library code changes:

1. **`version.json` moves from `1.70` to `1.74`.** v1.74.0 is the latest stable tag in `meraki/openapi`, published 2026-09-02 (v1.73.0 was 2026-08-05). This resets the Nerdbank.GitVersioning height, so builds jump from `1.70.138` to `1.74.x` rather than continuing to `1.70.139`. The `1.70.138` section stays in the changelog as history — it is accurate for what `main` built as at `84a0c39b`.

2. **A repeatable model gap diff**, `.github/skills/meraki-api-update/Find-MissingModelMembers.ps1`, plus its checked-in output `gap-report-v1.74.0.md`.

The bump asserts which spec version the library is *measured against*. It does **not** claim every 1.74 endpoint is implemented — the report below is exactly how far off that is.

## How the diff works

It reflects over the compiled Refit interfaces, matches each method's verb and path template to a spec operation, then walks every 2xx JSON response schema in parallel with the C# return type, comparing spec property names against `[DataMember]` names.

Three classes of legitimate mismatch are excluded, because the spec describes them as ordinary properties while the models correctly represent them as open-ended maps or as no payload:

- Dictionary-typed models — HTTP status-code maps, per-camera-model video settings.
- Methods declared to return the non-generic `Task`.
- Purely numeric property names — latency histogram buckets, HTTP status codes.

Each of those was a false positive observed in a real run before being filtered; without them the count is 234 rather than 155.

## What it found against v1.74.0

| Measure | Count |
|---|---|
| Refit endpoints in the library | 1075 |
| Operations in the v1.74.0 spec | 998 |
| Library endpoints matched to a spec operation | 861 |
| Library endpoints with no spec match | 214 |
| Spec operations not implemented | 140 |
| **Unmapped response members on existing models** | **155**, across 86 types |

118 of the 155 are scalars; 37 objects and 23 arrays need roughly 57 new nested classes alongside them.

| Area | Members | Of which object/array |
|---|---|---|
| Organizations | 43 | 22 |
| SM | 27 | 5 |
| Appliance | 25 | 13 |
| Wireless | 19 | 6 |
| General | 10 | 1 |
| Camera | 8 | 1 |
| CellularGateway | 7 | 1 |
| Switch | 7 | 2 |
| Sensor | 6 | 5 |
| LiveTools | 2 | 0 |
| Licensing | 1 | 1 |

Spot-checked and real: `SwitchPort.stpPortFastTrunk`, `Ssid.campusGateway` and `.wlanIdentifier`, `Vlan.sgt`, `Client.cdp`, and `SmVppAccount` missing 13 of its fields.

## Reproduce

```powershell
pwsh -File .\.github\skills\meraki-api-update\Prepare-MerakiApiUpdate.ps1 -Version 1.74.0
dotnet build Meraki.Api.slnx -c Debug
pwsh -File .\.github\skills\meraki-api-update\Find-MissingModelMembers.ps1 -SpecVersion v1.74.0 -OutCsv gap.csv
```

## Verification

```
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s), 6 pre-existing CS0618 warnings
Version of the branch head              1.74.4 (main will be 1.74.5 after a merge commit)
Meraki.Api.Test (Data namespace)        Total: 14, Errors: 0, Failed: 0, Skipped: 0
Meraki.Api.Test (Workflows)             Total: 12, Errors: 0, Failed: 0, Skipped: 0
```

**Merge with a merge commit** for the `1.74.5` changelog label to be correct; a squash makes it `1.74.4`.

## Follow-up

The 155 members land as one PR per product area, largest first, each with its own changelog entry and regression tests.

## Notes

- The 155 is the **accumulated** gap, not only what 1.71 → 1.74 added. No attempt was made to attribute each member to the release that introduced it.
- The **214 unmatched library endpoints** are not necessarily wrong — some are endpoints Cisco removed or renamed, some are path shapes the normaliser does not line up. They need their own pass; a few may be dead code.
- `SKILL.md` now tells the reader to run the diff rather than read the changelog narratively, and warns that a full run finds more than one release introduced.
- Cisco's What's New page still lists 1.73 as current, while the spec repo has tagged v1.74.0 — flagging in case 1.74 is not meant to be public yet.