### PR TITLE
fix: correct response shapes and member names that could never bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 ﻿# Changelog
 
+## 1.74.7
+
+### Breaking changes
+
+An audit against the v1.74.0 OpenAPI spec (`Find-ModelShapeMismatches.ps1`) found endpoints whose
+declared return type does not match the shape the Dashboard API sends, so the call could never
+deserialize, and `[DataMember]` names that are misspelt, so the property never bound. Fixing them
+changes public signatures and property names; each change is listed so callers can update.
+
+- **Six methods declared `List<T>` where the API sends an `{items, meta}` wrapper.** Each now
+  returns a wrapper type deriving from `ItemsResponseWithMeta<T>`:
+  `GetNetworkMovesAsync` → `NetworkMovesResponse`,
+  `GetOrganizationCampusGatewayClustersAsync` → `OrganizationCampusGatewayClustersResponse`,
+  `GetOrganizationSensorGatewaysConnectionsLatestAsync` → `OrganizationSensorGatewaysConnectionsLatestResponse`
+  (items are the existing `SensorGatewayConnectionsLatestItem`, not `SensorReadingLatest`),
+  `GetOrganizationSwitchPortsStatusesBySwitchAsync` → `OrganizationSwitchPortsStatusesBySwitchResponse`,
+  `GetOrganizationIntegrationsXdrNetworksAsync` → the existing wrapper `OrganizationIntegrationsXdrByNetwork`
+  (it was declared as a `List` of that wrapper), and
+  `UpdateOrganizationSmSentryPoliciesAssignments` → `OrganizationSmSentryPoliciesAssignmentsUpdateResponse`
+  (an `{items}` wrapper with no meta). Read `.Items` where you previously enumerated the result.
+
+- **Six methods declared a single object where the API sends an array.** Each now returns
+  `List<T>` of the type it previously returned:
+  `GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesAsync`,
+  `GetNetworkSmDeviceConnectivityAsync`, `UpdateNetworkFirmwareUpgradesStagedStagesAsync`,
+  `CreateOrganizationApplianceDnsLocalRecordAsync`, `GetOrganizationApplianceDnsLocalRecordsAsync`
+  and `CreateOrganizationDevicesControllerMigrationAsync`.
+
+- **Ten methods declared `List<T>` where the API sends a single object**, all single-resource paths:
+  `GetNetworkApplianceFirewallFirewalledServiceAsync` and `Update…` → `FirewalledService`;
+  `GetNetworkApplianceFirewallInboundCellularFirewallRulesAsync` and `Update…` →
+  `InboundCellularFirewallRules` (the `{rules}` object; the getter was declared as a bare list of
+  rules); `UpdateNetworkApplianceSdwanInternetPoliciesAsync` → `OrganizationApplianceSdwanInternetPolicies`
+  (it was declared as `List<SecurityEvent>`, an unrelated type); `GetDeviceCameraCustomAnalyticsAsync`
+  and `Update…` → `CameraCustomAnalytics`; `CreateOrganizationAdaptivePolicyAclAsync` → `AdaptivePolicyAcl`;
+  `GetDeviceSensorRelationshipsAsync` → `SensorRelationship`; `GetNetworkSmDeviceRestrictionsAsync` →
+  `SmDeviceRestrictions`.
+
+- **`CreateNetworkMoveAsync` now returns `NetworkMoveDetailed`.** The API stopped returning
+  `networkMoveId` and `url`, so neither property of `NetworkMove` bound; that type is now
+  `[Obsolete]` and will be removed in a later release. `NetworkMoveDetailed` gains `MoveId` (the
+  identifier the API now sends) and `Result` (a new `NetworkMoveResult` with `Status` and `Reason`);
+  its `Status` is no longer in the spec and becomes nullable.
+
+- **Misspelt member names corrected**, with the C# property renamed to match where it carried the
+  typo: `ConnectivityEvents.OccuredAt` → `OccurredAt` (`occurredAt`),
+  `SensorAlertConditionThresholdTemperature.Farenheit` → `Fahrenheit` (`fahrenheit`),
+  `OrganizationLicensingCotermLicenseMoveResponse.MoveLicenses` → `MovedLicenses` (`movedLicenses`),
+  `NetworkMoveDetailed.Initiator` (`intiator` → `initiator`),
+  `OrganizationSplashTheme.ThemeAssets` (`themeAssests` → `themeAssets`), and
+  `NetworksCampusGatewayClusterUplink.Addresses` (`address` → `addresses`).
+
+- **`Meta` on every `ItemsResponseWithMeta<T>` response was always empty.** The abstract base and the
+  `ItemsResponseMeta`, `ItemsResponseMetaCounts` and `ItemsResponseMetaCountsItems` classes lacked
+  `[DataContract]`, so on each opt-in derived wrapper Newtonsoft treated the inherited `Meta` as
+  ignored and dropped the API's `meta` object silently — pagination counts never arrived, and an
+  unmapped field inside `meta` could not be detected. All four now carry `[DataContract]`. Not a
+  signature change, but `Meta.Counts` will start being populated where it was previously null.
+
+- Three object-versus-list findings were left alone as the known Meraki spec habit of documenting a
+  list endpoint's item rather than the array (`GetNetworkWirelessRfProfilesAsync` is observed live
+  as an array), and five where the spec documents an array whose only item is itself an
+  `{items, meta}` wrapper (the library's wrapper is right). Regression tests in
+  `Meraki.Api.Test.Data.ResponseShapeTests` cover the new shapes and the corrected names.
+
 ## 1.74.5
 
 - **The library now tracks Dashboard API 1.74**, so `version.json` moves from `1.70` to `1.74`.

--- a/Meraki.Api.Test/Data/ResponseShapeTests.cs
+++ b/Meraki.Api.Test/Data/ResponseShapeTests.cs
@@ -1,0 +1,145 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for return types and member names that disagreed with the Dashboard API in a
+/// way that stopped the response binding at all: a <c>List</c> declared where the API sends an
+/// <c>{items, meta}</c> wrapper or a single object, a single object declared where the API sends an
+/// array, and misspelt <c>[DataMember]</c> names. Each payload has the shape the v1.74.0 OpenAPI
+/// spec documents, and is deserialized with the settings <see cref="JsonMissingMemberHandling.ThrowOnError"/>
+/// uses so an unmapped field fails the test.
+/// </summary>
+public class ResponseShapeTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// GET /organizations/{organizationId}/networks/moves - an {items, meta} wrapper, previously
+	// declared as List<NetworkMoveDetailed>. Also covers the "intiator" misspelling and the moveId
+	// and result members the spec now carries.
+	[Fact]
+	public void Deserialize_NetworkMovesResponse_BindsWrapperAndInitiator()
+	{
+		const string json = """
+			{
+				"items": [
+					{
+						"moveId": "1234567890123456789",
+						"createdAt": "2026-09-01T10:00:00Z",
+						"lastUpdatedAt": "2026-09-01T10:05:00Z",
+						"initiator": { "admin": { "id": "1" } },
+						"network": { "id": "N_1" },
+						"organizations": { "source": { "id": "10" }, "target": { "id": "20" } },
+						"result": { "status": "completed", "reason": null }
+					}
+				],
+				"meta": { "counts": { "items": { "total": 1, "remaining": 0 } } }
+			}
+			""";
+
+		var response = Deserialize<NetworkMovesResponse>(json);
+
+		_ = response.Items.Should().ContainSingle();
+		_ = response.Items[0].MoveId.Should().Be("1234567890123456789");
+		_ = response.Items[0].Initiator.Should().NotBeNull();
+		_ = response.Items[0].Result.Should().NotBeNull();
+		_ = response.Items[0].Result!.Status.Should().Be("completed");
+		_ = response.Meta.Counts!.Items.Total.Should().Be(1);
+	}
+
+	// PUT /organizations/{organizationId}/sm/sentry/policies/assignments - an {items} wrapper with
+	// no meta, previously declared as the item type.
+	[Fact]
+	public void Deserialize_SentryPoliciesAssignmentsUpdateResponse_BindsItems()
+	{
+		const string json = """
+			{ "items": [ { "networkId": "N_1", "policies": [] } ] }
+			""";
+
+		var response = Deserialize<OrganizationSmSentryPoliciesAssignmentsUpdateResponse>(json);
+
+		_ = response.Items.Should().ContainSingle().Which.NetworkId.Should().Be("N_1");
+	}
+
+	// GET /networks/{networkId}/appliance/firewall/inboundCellularFirewallRules - a {rules} object,
+	// previously declared as List<MxFirewallRule>.
+	[Fact]
+	public void Deserialize_InboundCellularFirewallRules_BindsRulesObject()
+	{
+		const string json = """
+			{ "rules": [ { "comment": "Allow", "policy": "allow", "protocol": "tcp", "srcPort": "Any", "srcCidr": "Any", "destPort": "443", "destCidr": "Any", "syslogEnabled": false } ] }
+			""";
+
+		var rules = Deserialize<InboundCellularFirewallRules>(json);
+
+		_ = rules.Rules.Should().ContainSingle();
+	}
+
+	// GET /networks/{networkId}/appliance/firewall/firewalledServices/{service} - a single object,
+	// previously declared as List<FirewalledService>.
+	[Fact]
+	public void Deserialize_FirewalledService_BindsSingleObject()
+	{
+		const string json = """
+			{ "service": "ICMP", "access": "restricted", "allowedIps": [ "192.0.2.10" ] }
+			""";
+
+		var service = Deserialize<FirewalledService>(json);
+
+		_ = service.AllowedIps.Should().ContainSingle();
+	}
+
+	// Misspelt [DataMember] names, each of which meant the property never bound.
+	[Fact]
+	public void Deserialize_ConnectivityEvents_BindsOccurredAt()
+	{
+		var events = Deserialize<ConnectivityEvents>("""{ "occurredAt": "2026-09-01T10:00:00Z" }""");
+
+		_ = events.OccurredAt.Should().Be(new DateTime(2026, 9, 1, 10, 0, 0, DateTimeKind.Utc));
+	}
+
+	[Fact]
+	public void Deserialize_SensorAlertConditionThresholdTemperature_BindsFahrenheit()
+	{
+		var threshold = Deserialize<SensorAlertConditionThresholdTemperature>("""{ "celsius": 20.5, "fahrenheit": 68.9 }""");
+
+		_ = threshold.Fahrenheit.Should().Be(68.9);
+	}
+
+	[Fact]
+	public void Deserialize_OrganizationSplashTheme_BindsThemeAssets()
+	{
+		var theme = Deserialize<OrganizationSplashTheme>("""{ "themeAssets": [] }""");
+
+		_ = theme.ThemeAssets.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Deserialize_OrganizationLicensingCotermLicenseMoveResponse_BindsMovedLicenses()
+	{
+		var response = Deserialize<OrganizationLicensingCotermLicenseMoveResponse>("""{ "movedLicenses": [] }""");
+
+		_ = response.MovedLicenses.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Deserialize_NetworksCampusGatewayClusterUplink_BindsAddresses()
+	{
+		var uplink = Deserialize<NetworksCampusGatewayClusterUplink>("""{ "addresses": [] }""");
+
+		_ = uplink.Addresses.Should().BeEmpty();
+	}
+}

--- a/Meraki.Api/Data/ConnectivityEvents.cs
+++ b/Meraki.Api/Data/ConnectivityEvents.cs
@@ -7,10 +7,10 @@
 public class ConnectivityEvents
 {
 	/// <summary>
-	/// Occured at
+	/// Occurred at
 	/// </summary>
-	[DataMember(Name = "occuredAt")]
-	public DateTime OccuredAt { get; set; }
+	[DataMember(Name = "occurredAt")]
+	public DateTime OccurredAt { get; set; }
 
 	/// <summary>
 	/// Device serial

--- a/Meraki.Api/Data/ItemsResponseMeta.cs
+++ b/Meraki.Api/Data/ItemsResponseMeta.cs
@@ -3,6 +3,7 @@ namespace Meraki.Api.Data;
 /// <summary>
 /// Items Response Meta
 /// </summary>
+[DataContract]
 public class ItemsResponseMeta
 {
 	/// <summary>

--- a/Meraki.Api/Data/ItemsResponseMetaCounts.cs
+++ b/Meraki.Api/Data/ItemsResponseMetaCounts.cs
@@ -3,6 +3,7 @@ namespace Meraki.Api.Data;
 /// <summary>
 /// Items Response Meta Counts
 /// </summary>
+[DataContract]
 public class ItemsResponseMetaCounts
 {
 	/// <summary>

--- a/Meraki.Api/Data/ItemsResponseMetaCountsItems.cs
+++ b/Meraki.Api/Data/ItemsResponseMetaCountsItems.cs
@@ -3,6 +3,7 @@ namespace Meraki.Api.Data;
 /// <summary>
 /// Items Response Meta Counts Items
 /// </summary>
+[DataContract]
 public class ItemsResponseMetaCountsItems
 {
 	/// <summary>

--- a/Meraki.Api/Data/ItemsResponseWithMeta.cs
+++ b/Meraki.Api/Data/ItemsResponseWithMeta.cs
@@ -4,6 +4,7 @@
 /// Response containing a list of items with metadata
 /// </summary>
 /// <typeparam name="T">The type of items in the response</typeparam>
+[DataContract]
 public abstract class ItemsResponseWithMeta<T>
 {
 	/// <summary>

--- a/Meraki.Api/Data/NetworkMove.cs
+++ b/Meraki.Api/Data/NetworkMove.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Network Move
 /// </summary>
+[Obsolete("The Dashboard API stopped returning networkMoveId and url from createNetworkMove; neither property binds. CreateNetworkMoveAsync now returns NetworkMoveDetailed, whose MoveId is the identifier. This type will be removed in a later release.")]
 [DataContract]
 public class NetworkMove
 {

--- a/Meraki.Api/Data/NetworkMoveDetailed.cs
+++ b/Meraki.Api/Data/NetworkMoveDetailed.cs
@@ -21,17 +21,32 @@ public class NetworkMoveDetailed
 	public string LastUpdatedAt { get; set; } = string.Empty;
 
 	/// <summary>
-	/// Current status of the network move operation. Possible values are pending, in progress, failed, and completed
+	/// ID of the network move operation
+	/// </summary>
+	[ApiKey]
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "moveId")]
+	public string MoveId { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Current status of the network move operation. No longer in the v1.74.0 spec, which reports it under <see cref="Result"/>; kept for responses that still send it.
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "status")]
-	public string Status { get; set; } = string.Empty;
+	public string? Status { get; set; }
+
+	/// <summary>
+	/// Result of the network move operation
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "result")]
+	public NetworkMoveResult? Result { get; set; }
 
 	/// <summary>
 	/// User who initiated the move
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "intiator")]
+	[DataMember(Name = "initiator")]
 	public NetworkMoveInitiator Initiator { get; set; } = new();
 
 	/// <summary>

--- a/Meraki.Api/Data/NetworkMoveResult.cs
+++ b/Meraki.Api/Data/NetworkMoveResult.cs
@@ -1,0 +1,22 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Result of a network move operation
+/// </summary>
+[DataContract]
+public class NetworkMoveResult
+{
+	/// <summary>
+	/// Current status of the network move operation. Possible values are pending, in progress, failed, completed, and invalidated
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "status")]
+	public string? Status { get; set; }
+
+	/// <summary>
+	/// More information about the status of the network move operation
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "reason")]
+	public string? Reason { get; set; }
+}

--- a/Meraki.Api/Data/NetworkMovesResponse.cs
+++ b/Meraki.Api/Data/NetworkMovesResponse.cs
@@ -1,0 +1,16 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Paginated list of network move operations in an organization
+/// </summary>
+[DataContract]
+public class NetworkMovesResponse
+	: ItemsResponseWithMeta<NetworkMoveDetailed>
+{
+	/// <summary>
+	/// Network move operations
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "items")]
+	public override List<NetworkMoveDetailed> Items { get; set; } = [];
+}

--- a/Meraki.Api/Data/NetworksCampusGatewayClusterUplink.cs
+++ b/Meraki.Api/Data/NetworksCampusGatewayClusterUplink.cs
@@ -16,7 +16,7 @@ public class NetworksCampusGatewayClusterUplink
 	/// <summary>
 	/// Uplink IP addresses of the device
 	/// </summary>
-	[DataMember(Name = "address")]
+	[DataMember(Name = "addresses")]
 	[ApiAccess(ApiAccess.ReadWrite)]
 	public List<NetworksCampusGatewayClusterDeviceIPAddress> Addresses { get; set; } = [];
 }

--- a/Meraki.Api/Data/OrganizationCampusGatewayClustersResponse.cs
+++ b/Meraki.Api/Data/OrganizationCampusGatewayClustersResponse.cs
@@ -1,0 +1,16 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Paginated list of campus gateway clusters in an organization
+/// </summary>
+[DataContract]
+public class OrganizationCampusGatewayClustersResponse
+	: ItemsResponseWithMeta<OrganizationCampusGatewayCluster>
+{
+	/// <summary>
+	/// Campus gateway clusters
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "items")]
+	public override List<OrganizationCampusGatewayCluster> Items { get; set; } = [];
+}

--- a/Meraki.Api/Data/OrganizationLicensingCotermLicenseMoveResponse.cs
+++ b/Meraki.Api/Data/OrganizationLicensingCotermLicenseMoveResponse.cs
@@ -10,8 +10,8 @@ public class OrganizationLicensingCotermLicenseMoveResponse
 	/// Newly moved licenses created in the destination organization of the license move operation
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "moveLicenses")]
-	public List<OrganizationLicensingCotermLicenseMoveResponseLicense> MoveLicenses { get; set; } = [];
+	[DataMember(Name = "movedLicenses")]
+	public List<OrganizationLicensingCotermLicenseMoveResponseLicense> MovedLicenses { get; set; } = [];
 
 	/// <summary>
 	/// Remainder licenses created in the source organization as a result of moving a subset of the counts of a license

--- a/Meraki.Api/Data/OrganizationSensorGatewaysConnectionsLatestResponse.cs
+++ b/Meraki.Api/Data/OrganizationSensorGatewaysConnectionsLatestResponse.cs
@@ -1,0 +1,16 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Paginated list of the latest sensor gateway connections in an organization
+/// </summary>
+[DataContract]
+public class OrganizationSensorGatewaysConnectionsLatestResponse
+	: ItemsResponseWithMeta<SensorGatewayConnectionsLatestItem>
+{
+	/// <summary>
+	/// Latest sensor gateway connections
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "items")]
+	public override List<SensorGatewayConnectionsLatestItem> Items { get; set; } = [];
+}

--- a/Meraki.Api/Data/OrganizationSmSentryPoliciesAssignmentsUpdateResponse.cs
+++ b/Meraki.Api/Data/OrganizationSmSentryPoliciesAssignmentsUpdateResponse.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Response to updating Sentry policy assignments across an organization
+/// </summary>
+[DataContract]
+public class OrganizationSmSentryPoliciesAssignmentsUpdateResponse
+{
+	/// <summary>
+	/// The Sentry policy assignments, one entry per network
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "items")]
+	public List<OrganizationSmSentryPoliciesAssignmentsResponse> Items { get; set; } = [];
+}

--- a/Meraki.Api/Data/OrganizationSplashTheme.cs
+++ b/Meraki.Api/Data/OrganizationSplashTheme.cs
@@ -10,6 +10,6 @@ public class OrganizationSplashTheme : NamedIdentifiedItem
 	/// list of theme assets
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadUpdate)]
-	[DataMember(Name = "themeAssests")]
+	[DataMember(Name = "themeAssets")]
 	public List<OrganizationSplashThemeThemeAsset> ThemeAssets { get; set; } = [];
 }

--- a/Meraki.Api/Data/OrganizationSwitchPortsStatusesBySwitchResponse.cs
+++ b/Meraki.Api/Data/OrganizationSwitchPortsStatusesBySwitchResponse.cs
@@ -1,0 +1,16 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Paginated list of switch port statuses grouped by switch in an organization
+/// </summary>
+[DataContract]
+public class OrganizationSwitchPortsStatusesBySwitchResponse
+	: ItemsResponseWithMeta<SwitchPortsStatusesBySwitch>
+{
+	/// <summary>
+	/// Switches with their port statuses
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "items")]
+	public override List<SwitchPortsStatusesBySwitch> Items { get; set; } = [];
+}

--- a/Meraki.Api/Data/SensorAlertConditionThresholdTemperature.cs
+++ b/Meraki.Api/Data/SensorAlertConditionThresholdTemperature.cs
@@ -20,9 +20,9 @@ public class SensorAlertConditionThresholdTemperature
 	public double? Celsius { get; set; }
 
 	/// <summary>
-	/// Temperature Threshold Farenheit
+	/// Temperature Threshold Fahrenheit
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadUpdate)]
-	[DataMember(Name = "farenheit")]
-	public double? Farenheit { get; set; }
+	[DataMember(Name = "fahrenheit")]
+	public double? Fahrenheit { get; set; }
 }

--- a/Meraki.Api/Interfaces/General/Administered/IAdministeredLicensingSubscriptionSubscriptionsCompliance.cs
+++ b/Meraki.Api/Interfaces/General/Administered/IAdministeredLicensingSubscriptionSubscriptionsCompliance.cs
@@ -13,7 +13,7 @@ public interface IAdministeredLicensingSubscriptionSubscriptionsCompliance
 	/// <returns></returns>
 	[ApiOperationId("getAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses")]
 	[Get("/administered/licensing/subscription/subscriptions/compliance/statuses")]
-	Task<AdministeredLicensingSubscriptionSubscriptionsComplianceStatuses> GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesAsync(
+	Task<List<AdministeredLicensingSubscriptionSubscriptionsComplianceStatuses>> GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesAsync(
 		string networkId,
 		CancellationToken cancellationToken = default
 	);

--- a/Meraki.Api/Interfaces/General/Networks/INetworksFirmwareUpgrades.cs
+++ b/Meraki.Api/Interfaces/General/Networks/INetworksFirmwareUpgrades.cs
@@ -200,7 +200,7 @@ public interface INetworksFirmwareUpgrades
 	/// <returns></returns>
 	[ApiOperationId("updateNetworkFirmwareUpgradesStagedStages")]
 	[Put("/networks/{networkId}/firmwareUpgrades/staged/stages")]
-	Task<NetworkFirmwareUpgradesStagedStage> UpdateNetworkFirmwareUpgradesStagedStagesAsync(
+	Task<List<NetworkFirmwareUpgradesStagedStage>> UpdateNetworkFirmwareUpgradesStagedStagesAsync(
 		string networkId,
 		[Body] NetworkFirmwareUpgradesStagedStageUpdateRequest updateNetworkFirmwareUpgradesStagedStages,
 		CancellationToken cancellationToken = default);

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationSwitches.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationSwitches.cs
@@ -79,7 +79,7 @@ public interface IOrganizationSwitches
 	/// <param name="cancellationToken"></param>
 	[ApiOperationId("getOrganizationSwitchPortsStatusesBySwitch")]
 	[Get("/organizations/{organizationId}/switch/ports/statuses/bySwitch")]
-	Task<List<SwitchPortsStatusesBySwitch>> GetOrganizationSwitchPortsStatusesBySwitchAsync(
+	Task<OrganizationSwitchPortsStatusesBySwitchResponse> GetOrganizationSwitchPortsStatusesBySwitchAsync(
 		string organizationId,
 		string? t0,
 		int? timespan,

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsAdaptivePolicyAcls.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsAdaptivePolicyAcls.cs
@@ -24,7 +24,7 @@ public interface IOrganizationsAdaptivePolicyAcls
 	/// <param name="acls">Body for creating an ACL</param>
 	/// <param name="cancellationToken"></param>
 	[Post("/organizations/{organizationId}/adaptivePolicy/acls")]
-	Task<List<AdaptivePolicyAcl>> CreateOrganizationAdaptivePolicyAclAsync(
+	Task<AdaptivePolicyAcl> CreateOrganizationAdaptivePolicyAclAsync(
 		string organizationId,
 		[Body] AdaptivePolicyAcl acls,
 		CancellationToken cancellationToken = default);

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsApplianceDnsLocalRecords.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsApplianceDnsLocalRecords.cs
@@ -13,7 +13,7 @@ public interface IOrganizationsApplianceDnsLocalRecord
 	/// <returns></returns>
 	[ApiOperationId("getOrganizationApplianceDnsLocalRecords")]
 	[Get("/organizations/{organizationId}/appliance/dns/local/records")]
-	Task<OrganizationApplianceDnsLocalRecordsResponse> GetOrganizationApplianceDnsLocalRecordsAsync(
+	Task<List<OrganizationApplianceDnsLocalRecordsResponse>> GetOrganizationApplianceDnsLocalRecordsAsync(
 		string organizationId,
 		CancellationToken cancellationToken = default);
 
@@ -27,7 +27,7 @@ public interface IOrganizationsApplianceDnsLocalRecord
 	/// <returns></returns>
 	[ApiOperationId("createOrganizationApplianceDnsLocalRecord")]
 	[Post("/organizations/{organizationId}/appliance/dns/local/records")]
-	Task<OrganizationApplianceDnsLocalRecordsResponse> CreateOrganizationApplianceDnsLocalRecordAsync(
+	Task<List<OrganizationApplianceDnsLocalRecordsResponse>> CreateOrganizationApplianceDnsLocalRecordAsync(
 		string organizationId,
 		OrganizationApplianceDnsLocalRecordsCreateRequest request,
 		CancellationToken cancellationToken = default);

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsCampusGatewayClusters.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsCampusGatewayClusters.cs
@@ -14,7 +14,7 @@ public interface IOrganizationsCampusGatewayClusters
 	/// <returns></returns>
 	[ApiOperationId("getOrganizationCampusGatewayClusters")]
 	[Get("/organizations/{organizationId}/campusGateway/clusters")]
-	Task<List<OrganizationCampusGatewayCluster>> GetOrganizationCampusGatewayClustersAsync(
+	Task<OrganizationCampusGatewayClustersResponse> GetOrganizationCampusGatewayClustersAsync(
 		string organizationId,
 		CancellationToken cancellationToken = default
 	);

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsDevicesController.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsDevicesController.cs
@@ -14,7 +14,7 @@ public interface IOrganizationsDevicesController
 	/// <returns></returns>
 	[ApiOperationId("createOrganizationDevicesControllerMigration")]
 	[Post("/organizations/{organizationId}/devices/controller/migrations")]
-	Task<OrganizationsDevicesControllerMigration> CreateOrganizationDevicesControllerMigrationAsync(
+	Task<List<OrganizationsDevicesControllerMigration>> CreateOrganizationDevicesControllerMigrationAsync(
 		string organizationId,
 		[Body] OrganizationsDevicesControllerMigrationCreateRequest request,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsIntegrationsXdr.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsIntegrationsXdr.cs
@@ -13,7 +13,7 @@ public interface IOrganizationsIntegrationsXdr
 	/// <returns></returns>
 	[ApiOperationId("getOrganizationIntegrationsXdrNetworks")]
 	[Get("/organizations/{organizationId}/integrations/xdr/networks")]
-	Task<List<OrganizationIntegrationsXdrByNetwork>> GetOrganizationIntegrationsXdrNetworksAsync(
+	Task<OrganizationIntegrationsXdrByNetwork> GetOrganizationIntegrationsXdrNetworksAsync(
 		string organizationId,
 		CancellationToken cancellationToken = default
 	);

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsNetworks.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsNetworks.cs
@@ -78,7 +78,7 @@ public interface IOrganizationsNetworks
 	/// <returns></returns>
 	[ApiOperationId("createNetworkMove")]
 	[Post("/organizations/{organizationId}/networks/moves")]
-	Task<NetworkMove> CreateNetworkMoveAsync(
+	Task<NetworkMoveDetailed> CreateNetworkMoveAsync(
 		string organizationId,
 		[Body] NetworkMoveRequest networkMoveRequest,
 		CancellationToken cancellationToken = default);
@@ -92,7 +92,7 @@ public interface IOrganizationsNetworks
 	/// <returns></returns>
 	[ApiOperationId("getNetworkMoves")]
 	[Get("/organizations/{organizationId}/networks/moves")]
-	Task<List<NetworkMoveDetailed>> GetNetworkMovesAsync(
+	Task<NetworkMovesResponse> GetNetworkMovesAsync(
 		string organizationId,
 		CancellationToken cancellationToken = default);
 

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsSmSentry.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsSmSentry.cs
@@ -29,7 +29,7 @@ public interface IOrganizationsSmSentry
 	/// <returns></returns>
 	[ApiOperationId("updateOrganizationSmSentryPoliciesAssignments")]
 	[Put("/organizations/{organizationId}/sm/sentry/policies/assignments")]
-	Task<OrganizationSmSentryPoliciesAssignmentsResponse> UpdateOrganizationSmSentryPoliciesAssignments(
+	Task<OrganizationSmSentryPoliciesAssignmentsUpdateResponse> UpdateOrganizationSmSentryPoliciesAssignments(
 		string organizationId,
 		[Body] OrganizationSmSentryPoliciesAssignmentsUpdateRequest request,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/Products/Appliance/IApplianceFirewallFirewalledServices.cs
+++ b/Meraki.Api/Interfaces/Products/Appliance/IApplianceFirewallFirewalledServices.cs
@@ -25,7 +25,7 @@ public interface IApplianceFirewallFirewalledServices
 	/// <param name="service">The serviceType</param>
 	/// <param name="cancellationToken"></param>
 	[Get("/networks/{networkId}/appliance/firewall/firewalledServices/{service}")]
-	Task<List<FirewalledService>> GetNetworkApplianceFirewallFirewalledServiceAsync(
+	Task<FirewalledService> GetNetworkApplianceFirewallFirewalledServiceAsync(
 		string networkId,
 		FirewalledServiceType service,
 		CancellationToken cancellationToken = default
@@ -40,7 +40,7 @@ public interface IApplianceFirewallFirewalledServices
 	/// <param name="firewalledService"></param>
 	/// <param name="cancellationToken"></param>
 	[Put("/networks/{networkId}/appliance/firewall/firewalledServices/{service}")]
-	Task<List<FirewalledService>> UpdateNetworkApplianceFirewallFirewalledServiceAsync(
+	Task<FirewalledService> UpdateNetworkApplianceFirewallFirewalledServiceAsync(
 		string networkId,
 		FirewalledServiceType service,
 		[Body] FirewalledService firewalledService,

--- a/Meraki.Api/Interfaces/Products/Appliance/IApplianceFirewallInboundCellularFirewallRules.cs
+++ b/Meraki.Api/Interfaces/Products/Appliance/IApplianceFirewallInboundCellularFirewallRules.cs
@@ -13,7 +13,7 @@ public interface IApplianceFirewallInboundCellularFirewallRules
 	/// <param name="cancellationToken"></param>
 	[ApiOperationId("getNetworkApplianceFirewallInboundCellularFirewallRules")]
 	[Get("/networks/{networkId}/appliance/firewall/inboundCellularFirewallRules")]
-	Task<List<MxFirewallRule>> GetNetworkApplianceFirewallInboundCellularFirewallRulesAsync(
+	Task<InboundCellularFirewallRules> GetNetworkApplianceFirewallInboundCellularFirewallRulesAsync(
 		string networkId,
 		CancellationToken cancellationToken = default
 		);
@@ -27,7 +27,7 @@ public interface IApplianceFirewallInboundCellularFirewallRules
 	/// <param name="cancellationToken"></param>
 	[ApiOperationId("updateNetworkApplianceFirewallInboundCellularFirewallRules")]
 	[Put("/networks/{networkId}/appliance/firewall/inboundCellularFirewallRules")]
-	Task<List<InboundCellularFirewallRules>> UpdateNetworkApplianceFirewallInboundCellularFirewallRulesAsync(
+	Task<InboundCellularFirewallRules> UpdateNetworkApplianceFirewallInboundCellularFirewallRulesAsync(
 		string networkId,
 		[Body] InboundCellularFirewallRules inboundCellularFirewallRules,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/Products/Appliance/IApplianceSdwanInternetPolicies.cs
+++ b/Meraki.Api/Interfaces/Products/Appliance/IApplianceSdwanInternetPolicies.cs
@@ -14,7 +14,7 @@ public interface IApplianceSdwanInternetPolicies
 	/// <param name="cancellationToken"></param>
 	[ApiOperationId("updateNetworkApplianceSdwanInternetPolicies")]
 	[Put("/networks/{networkId}/appliance/sdwan/internetPolicies")]
-	Task<List<SecurityEvent>> UpdateNetworkApplianceSdwanInternetPoliciesAsync(
+	Task<OrganizationApplianceSdwanInternetPolicies> UpdateNetworkApplianceSdwanInternetPoliciesAsync(
 		string networkId,
 		[Body] ApplianceSdwanInternetPoliciesUpdate applianceSdwanInternetPoliciesUpdate,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/Products/Camera/ICameraCustomAnalytics.cs
+++ b/Meraki.Api/Interfaces/Products/Camera/ICameraCustomAnalytics.cs
@@ -12,7 +12,7 @@ public interface ICameraCustomAnalytics
 	/// <param name="serial">The serial number</param>
 	/// <param name="cancellationToken"></param>
 	[Get("/devices/{serial}/camera/customAnalytics")]
-	Task<List<CameraCustomAnalytics>> GetDeviceCameraCustomAnalyticsAsync(
+	Task<CameraCustomAnalytics> GetDeviceCameraCustomAnalyticsAsync(
 		string serial,
 		CancellationToken cancellationToken = default
 		);
@@ -25,7 +25,7 @@ public interface ICameraCustomAnalytics
 	/// <param name="cameraCustomAnalyticsUpdate">Body for updating camera custom analytics</param>
 	/// <param name="cancellationToken"></param>
 	[Put("/devices/{serial}/camera/customAnalytics")]
-	Task<List<CameraCustomAnalytics>> UpdateDeviceCameraCustomAnalyticsAsync(
+	Task<CameraCustomAnalytics> UpdateDeviceCameraCustomAnalyticsAsync(
 		string serial,
 		[Body] CameraCustomAnalyticsUpdate cameraCustomAnalyticsUpdate,
 		CancellationToken cancellationToken = default

--- a/Meraki.Api/Interfaces/Products/Sensor/IOrganizationSensorGatewaysConnectionsLatest.cs
+++ b/Meraki.Api/Interfaces/Products/Sensor/IOrganizationSensorGatewaysConnectionsLatest.cs
@@ -17,7 +17,7 @@ public interface IOrganizationSensorGatewaysConnectionsLatest
 	/// <param name="cancellationToken"></param>
 	[ApiOperationId("getOrganizationSensorGatewaysConnectionsLatest")]
 	[Get("/organizations/{organizationId}/sensor/gateways/connections/latest")]
-	Task<List<SensorReadingLatest>> GetOrganizationSensorGatewaysConnectionsLatestAsync(
+	Task<OrganizationSensorGatewaysConnectionsLatestResponse> GetOrganizationSensorGatewaysConnectionsLatestAsync(
 		string organizationId,
 		int? perPage,
 		string? startingAfter = null,

--- a/Meraki.Api/Interfaces/Products/Sensor/IOrganizationSensorRelationships.cs
+++ b/Meraki.Api/Interfaces/Products/Sensor/IOrganizationSensorRelationships.cs
@@ -13,7 +13,7 @@ public interface IOrganizationSensorRelationships
 	/// <param name="cancellationToken"></param>
 	[ApiOperationId("getDeviceSensorRelationships")]
 	[Get("/devices/{serial}/sensor/relationships")]
-	Task<List<SensorRelationship>> GetDeviceSensorRelationshipsAsync(
+	Task<SensorRelationship> GetDeviceSensorRelationshipsAsync(
 		string serial,
 		CancellationToken cancellationToken = default
 		);

--- a/Meraki.Api/Interfaces/Products/Sm/ISmDevicesConnectivity.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmDevicesConnectivity.cs
@@ -16,7 +16,7 @@ public interface ISmDevicesConnectivity
 	/// <param name="endingBefore">A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it. (optional)</param>
 	/// <param name="cancellationToken"></param>
 	[Get("/networks/{networkId}/sm/devices/{deviceId}/connectivity")]
-	Task<DeviceConnectivity> GetNetworkSmDeviceConnectivityAsync(
+	Task<List<DeviceConnectivity>> GetNetworkSmDeviceConnectivityAsync(
 		string networkId,
 		string deviceId,
 		int? perPage = 1000,

--- a/Meraki.Api/Interfaces/Products/Sm/ISmDevicesRestrictions.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmDevicesRestrictions.cs
@@ -13,7 +13,7 @@ public interface ISmDevicesRestrictions
 	/// <param name="deviceId">The device id</param>
 	/// <param name="cancellationToken"></param>
 	[Get("/networks/{networkId}/sm/devices/{deviceId}/restrictions")]
-	Task<List<SmDeviceRestrictions>> GetNetworkSmDeviceRestrictionsAsync(
+	Task<SmDeviceRestrictions> GetNetworkSmDeviceRestrictionsAsync(
 		string networkId,
 		string deviceId,
 		CancellationToken cancellationToken = default


### PR DESCRIPTION
## Stacked on #415

Base is `chore/update-to-latest-meraki-api`. Merge [#415](https://github.com/panoramicdata/Meraki.Api/pull/415) first, then retarget this to `main`. **Merge both with merge commits** — the changelog labels (`1.74.5` for #415, `1.74.7` for this) assume that — a merge commit adds one to the height; a squash shifts them.

## What

`Find-ModelShapeMismatches.ps1` (added in #415) found endpoints whose declared return type cannot deserialize what the Dashboard API sends, and `[DataMember]` names that are misspelt so the property never bound. This PR fixes every finding assessed as real. **It is breaking**: public return types and property names change. Each is listed in the `1.74.7` changelog section.

| Class of defect | Count | Fix |
|---|---|---|
| `List<T>` where the API sends `{items, meta}` | 6 | wrapper types deriving from `ItemsResponseWithMeta<T>` (one already existed and was wrapped in a `List`) |
| Single object where the API sends an array | 6 | `List<T>` |
| `List<T>` where the API sends a single object (single-resource paths) | 10 | `T` — one was `List<SecurityEvent>`, an unrelated type |
| Stale model: `NetworkMove` has neither property the API now sends | 1 | `CreateNetworkMoveAsync` → `NetworkMoveDetailed`; `NetworkMove` `[Obsolete]`; `MoveId` + `Result` added |
| Misspelt `[DataMember]` names | 6 | corrected, property renamed where it carried the typo |

### Found while writing the tests

`ItemsResponseWithMeta<T>` and the three `ItemsResponseMeta*` classes had no `[DataContract]`. Because each derived wrapper *is* `[DataContract]` (opt-in), Newtonsoft marked the inherited `Meta` as **ignored** and silently dropped the API's `meta` object — for every existing wrapper, not just the new ones. Verified by resolving the contract: `Meta <- Meta ignored=True`. Fixed by adding `[DataContract]` to all four; `Meta.Counts` will start being populated where it was always `null`.

### Deliberately not changed

- Three object-vs-list findings are the known Meraki spec habit of documenting a list endpoint's item rather than the array (`GetNetworkWirelessRfProfilesAsync` is observed live as an array in the customer CSV).
- Five endpoints the spec documents as an array whose only item is itself `{items, meta}` — the library's wrapper is right.
- `NetworkFirmwareUpgrade.products` flagged as a typo of `product` — false positive, both exist in the spec.

## Callers

No code outside `Meraki.Api/Interfaces` and `Meraki.Api/Data` references any changed method or property (checked `Meraki.Api`, `Meraki.Api.Test`, `Meraki.ApiChecker`).

## Verification

```
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s), 6 pre-existing CS0618 warnings
Meraki.Api.Test (Data namespace)        Total: 23, Errors: 0, Failed: 0   (9 new in ResponseShapeTests)
Meraki.Api.Test (Workflows)             Total: 12, Errors: 0, Failed: 0
```

The `NetworkMovesResponse` test failed first time with `Meta.Counts == null`, which is how the `[DataContract]` bug was found; it passes now. Every edited file kept its BOM and CRLF.