### PR TITLE
feat: map the Organizations-area response members from the 1.74.0 gap report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 ﻿# Changelog
 
+## 1.74.9
+
+- **Thirty Organizations-area response members the v1.74.0 spec documents are now mapped**, the
+  first of the per-area batches from the gap report in `.github/skills/meraki-api-update/`. Scalars:
+  `EarlyAccessFeatureOptInOptOutEligibilityHelp.Label`, `LoginSecurity.EnforceLockedIpSessions`,
+  `NextUpgrade.Strategy`, `OrganizationAdaptivePolicyOverviewCounts.CustomGroups` and
+  `.PolicyObjects`, `OrganizationAssuranceAlertScopeDevice.ProductType`,
+  `OrganizationAssuranceAlertsOverviewByNetworkItem.LastAlertedAt`, `OrganizationDevice.Imei`,
+  `OrganizationSplashTheme.IsSystemTheme`, `SamlIdp.SsoLoginUrl` and `.VisionConsumerUrl`. Nested:
+  `FirmwareProducts.CampusGateway`, `NetworkFirmwareUpdateStagedEventsProducts.SwitchCatalyst` and
+  `NetworkFirmwareUpgradeStagedEventsProduct.SwitchCatalyst` (reusing the existing product types),
+  `NetworkStatusSummary.Group` and `.Permissions`, `NextUpgrade.Predownload`,
+  `OrganizationAdaptivePolicyOverview.Limits` and `WebhookAlertType.Example`, backed by six new
+  classes. Everything is read-only except where the spec puts the member on a request body
+  (`NextUpgrade.Strategy`/`.Predownload`, `LoginSecurity.EnforceLockedIpSessions`, the firmware
+  product entries), which are read/update.
+
+- **Three models in this area had never matched the API and are corrected**, which is breaking for
+  anyone reading the old members (they were always default-valued):
+  - `OrganizationAssuranceAlertsOverviewByTypeItem` carried a copy of the by-network item's members
+    (`AlertCount`, `NetworkId`, `NetworkName`, `SeverityCounts`). It now has the documented shape:
+    `Type`, `CategoryType`, `Severity`, `Count`, `NetworkCount`, `Networks`, `DeviceTypes`,
+    `DeviceTags`, `LastAlertedAt`, `LastResolvedAt`. `OrganizationAssuranceAlertsOverviewByTypeItemSeverityCount`
+    is `[Obsolete]` and will be removed.
+  - `WebhookAlertType` had the example payload's fields flattened onto the alert type; the API sends
+    them under `example`. They are now `[Obsolete]` at the top level and available on `Example`,
+    which also carries `NetworkTags`, `EnrollmentString`, `Notes`, `ProductTypes` and `EncryptedId`.
+  - `OrganizationDevicesSyslogServersRolesByNetworkItem.AvailableRoles` was mapped to
+    `availableRoles`; the API sends `available`. The C# name is unchanged.
+
+  Regression tests are in `Meraki.Api.Test.Data.OrganizationsMemberTests`.
+
 ## 1.74.7
 
 ### Breaking changes

--- a/Meraki.Api.Test/Data/OrganizationsMemberTests.cs
+++ b/Meraki.Api.Test/Data/OrganizationsMemberTests.cs
@@ -1,0 +1,115 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for Organizations-area response members the v1.74.0 OpenAPI spec documents that
+/// the models lacked. Each payload has the shape the spec documents, and is deserialized with the
+/// settings <see cref="JsonMissingMemberHandling.ThrowOnError"/> uses so an unmapped field fails
+/// the test rather than being dropped.
+/// </summary>
+public class OrganizationsMemberTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// products.wireless.nextUpgrade from GET /networks/{networkId}/firmwareUpgrades
+	[Fact]
+	public void Deserialize_NextUpgrade_MapsStrategyAndPredownload()
+	{
+		var next = Deserialize<NextUpgrade>("""
+			{ "time": "2026-09-10T02:00:00Z", "strategy": "minimizeClientDowntime", "predownload": { "enabled": true }, "toVersion": { "id": "1", "shortName": "MR 31.1", "firmware": "wireless-31-1", "releaseType": "stable", "releaseDate": "2026-08-01T00:00:00Z" } }
+			""");
+
+		_ = next.Strategy.Should().Be("minimizeClientDowntime");
+		_ = next.Predownload!.Enabled.Should().BeTrue();
+	}
+
+	// GET /organizations/{organizationId}/summary/top/networks/byStatus
+	[Fact]
+	public void Deserialize_NetworkStatusSummary_MapsGroupAndPermissions()
+	{
+		var summary = Deserialize<NetworkStatusSummary>("""
+			{ "networkId": "N_1", "name": "HQ", "url": "https://example.invalid", "tags": [], "productTypes": [ "wireless" ], "group": { "id": "G_1" }, "permissions": { "canWrite": true } }
+			""");
+
+		_ = summary.Group!.Id.Should().Be("G_1");
+		_ = summary.Permissions!.CanWrite.Should().BeTrue();
+	}
+
+	// GET /organizations/{organizationId}/adaptivePolicy/overview
+	[Fact]
+	public void Deserialize_OrganizationAdaptivePolicyOverview_MapsLimitsAndNewCounts()
+	{
+		var overview = Deserialize<OrganizationAdaptivePolicyOverview>("""
+			{ "counts": { "groups": 3, "customGroups": 2, "customAcls": 1, "policies": 4, "denyPolicies": 1, "allowPolicies": 3, "policyObjects": 5 }, "limits": { "customGroups": 100, "rulesInAnAcl": 200, "aclsInAPolicy": 10, "policyObjects": 500 } }
+			""");
+
+		_ = overview.Counts.CustomGroups.Should().Be(2);
+		_ = overview.Counts.PolicyObjects.Should().Be(5);
+		_ = overview.Limits!.RulesInAnAcl.Should().Be(200);
+	}
+
+	// items[] from GET /organizations/{organizationId}/assurance/alerts/overview/byType - the model
+	// previously carried the by-network item's members, none of which the API sends here.
+	[Fact]
+	public void Deserialize_OrganizationAssuranceAlertsOverviewByTypeItem_MapsDocumentedShape()
+	{
+		var item = Deserialize<OrganizationAssuranceAlertsOverviewByTypeItem>("""
+			{ "type": "device_offline", "categoryType": "connectivity", "severity": "critical", "count": 7, "networkCount": 2, "networks": [ { "id": "N_1", "name": "HQ" } ], "deviceTypes": [ "switch" ], "deviceTags": [ "core" ], "lastAlertedAt": "2026-09-09T10:00:00Z", "lastResolvedAt": null }
+			""");
+
+		_ = item.Count.Should().Be(7);
+		_ = item.Networks.Should().ContainSingle().Which.Name.Should().Be("HQ");
+		_ = item.LastResolvedAt.Should().BeNull();
+	}
+
+	// items[] from GET /organizations/{organizationId}/devices/syslogServers/roles/byNetwork - the
+	// member is "available", not "availableRoles".
+	[Fact]
+	public void Deserialize_OrganizationDevicesSyslogServersRolesByNetworkItem_MapsAvailable()
+	{
+		var item = Deserialize<OrganizationDevicesSyslogServersRolesByNetworkItem>("""
+			{ "network": { "id": "N_1" }, "available": [ { "name": "Wireless event log", "value": "Wireless event log" } ] }
+			""");
+
+		_ = item.AvailableRoles.Should().ContainSingle();
+	}
+
+	// GET /organizations/{organizationId}/webhooks/alertTypes - the example payload is nested, not
+	// flattened onto the alert type.
+	[Fact]
+	public void Deserialize_WebhookAlertType_MapsExample()
+	{
+		var alertType = Deserialize<WebhookAlertType>("""
+			{ "alertTypeId": "power_supply_down", "alertType": "Power supply went down", "example": { "version": "0.1", "sharedSecret": "secret", "sentAt": "2026-09-09T10:00:00Z", "alertId": "1", "alertType": "Power supply went down", "alertTypeId": "power_supply_down", "alertLevel": "critical", "occurredAt": "2026-09-09T09:59:00Z", "alertData": { "supply": 1 }, "organizationId": "1", "organizationName": "Example", "organizationUrl": "https://example.invalid", "deviceSerial": "Q2XX-ABCD-1234", "deviceMac": "00:11:22:33:44:55", "deviceName": "sw1", "deviceUrl": "https://example.invalid", "deviceTags": [], "deviceModel": "MS", "networkId": "N_1", "networkName": "HQ", "networkUrl": "https://example.invalid", "networkTags": [], "enrollmentString": null, "notes": null, "productTypes": [ "switch" ], "encryptedId": "x" } }
+			""");
+
+		_ = alertType.Example!.AlertLevel.Should().Be("critical");
+		_ = alertType.Example.ProductTypes.Should().ContainSingle();
+	}
+
+	// GET /organizations/{organizationId}/saml/idps/{idpId}
+	[Fact]
+	public void Deserialize_SamlIdp_MapsSsoLoginUrlAndVisionConsumerUrl()
+	{
+		var idp = Deserialize<SamlIdp>("""
+			{ "idpId": "1", "consumerUrl": "https://example.invalid/c", "visionConsumerUrl": "https://example.invalid/v", "x509certSha1Fingerprint": "00:11", "ssoLoginUrl": "https://example.invalid/sso", "sloLogoutUrl": "https://example.invalid/slo" }
+			""");
+
+		_ = idp.SsoLoginUrl.Should().Be("https://example.invalid/sso");
+		_ = idp.VisionConsumerUrl.Should().Be("https://example.invalid/v");
+	}
+}

--- a/Meraki.Api/Data/EarlyAccessFeatureOptInOptOutEligibilityHelp.cs
+++ b/Meraki.Api/Data/EarlyAccessFeatureOptInOptOutEligibilityHelp.cs
@@ -19,4 +19,11 @@ public class EarlyAccessFeatureOptInOptOutEligibilityHelp
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "url")]
 	public string Url { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Help link label
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "label")]
+	public string? Label { get; set; }
 }

--- a/Meraki.Api/Data/FirmwareProducts.cs
+++ b/Meraki.Api/Data/FirmwareProducts.cs
@@ -90,4 +90,11 @@ public class FirmwareProducts
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "wirelessController")]
 	public FirmwareUpgradeProduct WirelessController { get; set; } = new();
+
+	/// <summary>
+	/// The campus gateway devices to be updated
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "campusGateway")]
+	public FirmwareUpgradeProduct? CampusGateway { get; set; }
 }

--- a/Meraki.Api/Data/LoginSecurity.cs
+++ b/Meraki.Api/Data/LoginSecurity.cs
@@ -103,4 +103,11 @@ public class LoginSecurity
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "minimumPasswordLength")]
 	public int? MinimumPasswordLength { get; set; }
+
+	/// <summary>
+	/// Boolean indicating whether Dashboard sessions are locked to the IP address they were established from. Only included for organizations that support locked-IP sessions.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "enforceLockedIpSessions")]
+	public bool? EnforceLockedIpSessions { get; set; }
 }

--- a/Meraki.Api/Data/NetworkFirmwareUpdateStagedEventsProducts.cs
+++ b/Meraki.Api/Data/NetworkFirmwareUpdateStagedEventsProducts.cs
@@ -12,4 +12,11 @@ public class NetworkFirmwareUpdateStagedEventsProducts
 	[DataMember(Name = "switch")]
 	[ApiAccess(ApiAccess.ReadWrite)]
 	public NetworkFirmwareUpgradeStagedEventsSwitch? Switch { get; set; }
+
+	/// <summary>
+	/// The Catalyst Switch network to be updated
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "switchCatalyst")]
+	public NetworkFirmwareUpgradeStagedEventsSwitch? SwitchCatalyst { get; set; }
 }

--- a/Meraki.Api/Data/NetworkFirmwareUpgradeStagedEventsProduct.cs
+++ b/Meraki.Api/Data/NetworkFirmwareUpgradeStagedEventsProduct.cs
@@ -12,4 +12,11 @@ public class NetworkFirmwareUpgradeStagedEventsProduct
 	[DataMember(Name = "switch")]
 	[ApiAccess(ApiAccess.ReadWrite)]
 	public NetworkFirmwareUpgradeStagedEventsSwitch? Switch { get; set; }
+
+	/// <summary>
+	/// The Catalyst Switch network to be updated
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "switchCatalyst")]
+	public NetworkFirmwareUpgradeStagedEventsSwitch? SwitchCatalyst { get; set; }
 }

--- a/Meraki.Api/Data/NetworkStatusSummary.cs
+++ b/Meraki.Api/Data/NetworkStatusSummary.cs
@@ -61,4 +61,18 @@ public class NetworkStatusSummary
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "statuses")]
 	public NetworkStatusSummaryStatuses Statuses { get; set; } = new();
+
+	/// <summary>
+	/// Network group membership
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "group")]
+	public NetworkStatusSummaryGroup? Group { get; set; }
+
+	/// <summary>
+	/// Current user's network-level permissions
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "permissions")]
+	public NetworkStatusSummaryPermissions? Permissions { get; set; }
 }

--- a/Meraki.Api/Data/NetworkStatusSummaryGroup.cs
+++ b/Meraki.Api/Data/NetworkStatusSummaryGroup.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Network group membership
+/// </summary>
+[DataContract]
+public class NetworkStatusSummaryGroup
+{
+	/// <summary>
+	/// ID of the network group
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "id")]
+	public string? Id { get; set; }
+}

--- a/Meraki.Api/Data/NetworkStatusSummaryPermissions.cs
+++ b/Meraki.Api/Data/NetworkStatusSummaryPermissions.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The current user's network-level permissions
+/// </summary>
+[DataContract]
+public class NetworkStatusSummaryPermissions
+{
+	/// <summary>
+	/// Whether the current user can write to the network
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "canWrite")]
+	public bool? CanWrite { get; set; }
+}

--- a/Meraki.Api/Data/NextUpgrade.cs
+++ b/Meraki.Api/Data/NextUpgrade.cs
@@ -19,4 +19,18 @@ public class NextUpgrade
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "toVersion")]
 	public Version ToVersion { get; set; } = new();
+
+	/// <summary>
+	/// The strategy that network devices will use to perform the upgrade: 'minimizeClientDowntime' or 'minimizeUpgradeTime'. If unspecified, the scheduled upgrade will use the default strategy for the network.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "strategy")]
+	public string? Strategy { get; set; }
+
+	/// <summary>
+	/// Predownload settings for the firmware upgrade
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "predownload")]
+	public NextUpgradePredownload? Predownload { get; set; }
 }

--- a/Meraki.Api/Data/NextUpgradePredownload.cs
+++ b/Meraki.Api/Data/NextUpgradePredownload.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Predownload settings for a scheduled firmware upgrade
+/// </summary>
+[DataContract]
+public class NextUpgradePredownload
+{
+	/// <summary>
+	/// Whether the firmware is downloaded to the devices ahead of the scheduled upgrade
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/OrganizationAdaptivePolicyOverview.cs
+++ b/Meraki.Api/Data/OrganizationAdaptivePolicyOverview.cs
@@ -11,4 +11,11 @@ public class OrganizationAdaptivePolicyOverview
 	/// </summary>
 	[DataMember(Name = "counts")]
 	public OrganizationAdaptivePolicyOverviewCounts Counts { get; set; } = new();
+
+	/// <summary>
+	/// The current limits of various adaptive policy objects
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "limits")]
+	public OrganizationAdaptivePolicyOverviewLimits? Limits { get; set; }
 }

--- a/Meraki.Api/Data/OrganizationAdaptivePolicyOverviewCounts.cs
+++ b/Meraki.Api/Data/OrganizationAdaptivePolicyOverviewCounts.cs
@@ -35,4 +35,18 @@ public class OrganizationAdaptivePolicyOverviewCounts
 	/// </summary>
 	[DataMember(Name = "allowPolicies")]
 	public int AllowPolicies { get; set; }
+
+	/// <summary>
+	/// Number of user-created adaptive policy groups currently in the organization
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "customGroups")]
+	public int? CustomGroups { get; set; }
+
+	/// <summary>
+	/// Number of policy objects (with the adaptive policy type) currently in the organization
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "policyObjects")]
+	public int? PolicyObjects { get; set; }
 }

--- a/Meraki.Api/Data/OrganizationAdaptivePolicyOverviewLimits.cs
+++ b/Meraki.Api/Data/OrganizationAdaptivePolicyOverviewLimits.cs
@@ -1,0 +1,36 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The current limits of various adaptive policy objects
+/// </summary>
+[DataContract]
+public class OrganizationAdaptivePolicyOverviewLimits
+{
+	/// <summary>
+	/// Maximum number of user-created adaptive policy groups allowed in the organization
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "customGroups")]
+	public int? CustomGroups { get; set; }
+
+	/// <summary>
+	/// Maximum number of rules allowed in an adaptive policy ACL
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "rulesInAnAcl")]
+	public int? RulesInAnAcl { get; set; }
+
+	/// <summary>
+	/// Maximum number of ACLs allowed in an adaptive policy
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "aclsInAPolicy")]
+	public int? AclsInAPolicy { get; set; }
+
+	/// <summary>
+	/// Maximum number of policy objects (with the adaptive policy type) allowed in the organization
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "policyObjects")]
+	public int? PolicyObjects { get; set; }
+}

--- a/Meraki.Api/Data/OrganizationAssuranceAlertScopeDevice.cs
+++ b/Meraki.Api/Data/OrganizationAssuranceAlertScopeDevice.cs
@@ -61,4 +61,11 @@ public class OrganizationAssuranceAlertScopeDevice
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "lldp")]
 	public OrganizationAssuranceAlertScopeDeviceLldp Lldp { get; set; } = new();
+
+	/// <summary>
+	/// Type of affected device
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "productType")]
+	public string? ProductType { get; set; }
 }

--- a/Meraki.Api/Data/OrganizationAssuranceAlertsOverviewByNetworkItem.cs
+++ b/Meraki.Api/Data/OrganizationAssuranceAlertsOverviewByNetworkItem.cs
@@ -33,4 +33,11 @@ public class OrganizationAssuranceAlertsOverviewByNetworkItem
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "severityCounts")]
 	public List<OrganizationAssuranceAlertsOverviewByNetworkItemSeverityCount> SeverityCounts { get; set; } = [];
+
+	/// <summary>
+	/// Last time an alert was seen for this network
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "lastAlertedAt")]
+	public DateTime? LastAlertedAt { get; set; }
 }

--- a/Meraki.Api/Data/OrganizationAssuranceAlertsOverviewByTypeItem.cs
+++ b/Meraki.Api/Data/OrganizationAssuranceAlertsOverviewByTypeItem.cs
@@ -7,30 +7,72 @@ namespace Meraki.Api.Data;
 public class OrganizationAssuranceAlertsOverviewByTypeItem
 {
 	/// <summary>
-	/// Total Alerts
+	/// Alert type
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "alertCount")]
-	public int AlertCount { get; set; }
+	[DataMember(Name = "type")]
+	public string? Type { get; set; }
 
 	/// <summary>
-	/// id
+	/// Alert category
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "networkId")]
-	public string NetworkId { get; set; } = string.Empty;
+	[DataMember(Name = "categoryType")]
+	public string? CategoryType { get; set; }
 
 	/// <summary>
-	/// Name
+	/// Alert severity
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "networkName")]
-	public string NetworkName { get; set; } = string.Empty;
+	[DataMember(Name = "severity")]
+	public string? Severity { get; set; }
 
 	/// <summary>
-	/// Alerts By Severity
+	/// Total count of the given alert type
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "severityCounts")]
-	public List<OrganizationAssuranceAlertsOverviewByTypeItemSeverityCount> SeverityCounts { get; set; } = [];
+	[DataMember(Name = "count")]
+	public int? Count { get; set; }
+
+	/// <summary>
+	/// Number of affected networks for the alert type
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "networkCount")]
+	public int? NetworkCount { get; set; }
+
+	/// <summary>
+	/// Affected networks for alerts in the group
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "networks")]
+	public List<OrganizationAssuranceAlertsOverviewByTypeItemNetwork> Networks { get; set; } = [];
+
+	/// <summary>
+	/// Affected device types for alerts in the group
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "deviceTypes")]
+	public List<string> DeviceTypes { get; set; } = [];
+
+	/// <summary>
+	/// Unique device tags for alerts in the group
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "deviceTags")]
+	public List<string> DeviceTags { get; set; } = [];
+
+	/// <summary>
+	/// Last time an alert of this type was triggered
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "lastAlertedAt")]
+	public DateTime? LastAlertedAt { get; set; }
+
+	/// <summary>
+	/// Last time an alert of this type was resolved
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "lastResolvedAt")]
+	public DateTime? LastResolvedAt { get; set; }
 }

--- a/Meraki.Api/Data/OrganizationAssuranceAlertsOverviewByTypeItemNetwork.cs
+++ b/Meraki.Api/Data/OrganizationAssuranceAlertsOverviewByTypeItemNetwork.cs
@@ -1,0 +1,22 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// A network affected by alerts of a given type
+/// </summary>
+[DataContract]
+public class OrganizationAssuranceAlertsOverviewByTypeItemNetwork
+{
+	/// <summary>
+	/// Network ID
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "id")]
+	public string? Id { get; set; }
+
+	/// <summary>
+	/// Network name
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "name")]
+	public string? Name { get; set; }
+}

--- a/Meraki.Api/Data/OrganizationAssuranceAlertsOverviewByTypeItemSeverityCount.cs
+++ b/Meraki.Api/Data/OrganizationAssuranceAlertsOverviewByTypeItemSeverityCount.cs
@@ -3,6 +3,7 @@ namespace Meraki.Api.Data;
 /// <summary>
 /// Organization Assurance Alerts Overview By Type Item Severity Count
 /// </summary>
+[Obsolete("The Dashboard API never returned severity counts on the by-type overview; OrganizationAssuranceAlertsOverviewByTypeItem now follows the documented shape. This type will be removed in a later release.")]
 [DataContract]
 public class OrganizationAssuranceAlertsOverviewByTypeItemSeverityCount
 {

--- a/Meraki.Api/Data/OrganizationDevice.cs
+++ b/Meraki.Api/Data/OrganizationDevice.cs
@@ -132,4 +132,11 @@ public class OrganizationDevice : NamedItem
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "details")]
 	public List<DeviceDetail>? Details { get; set; }
+
+	/// <summary>
+	/// IMEI of the device, if applicable
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "imei")]
+	public string? Imei { get; set; }
 }

--- a/Meraki.Api/Data/OrganizationDevicesSyslogServersRolesByNetworkItem.cs
+++ b/Meraki.Api/Data/OrganizationDevicesSyslogServersRolesByNetworkItem.cs
@@ -17,6 +17,6 @@ public class OrganizationDevicesSyslogServersRolesByNetworkItem
 	/// The list of roles that can be assigned to a syslog server for this network
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadWrite)]
-	[DataMember(Name = "availableRoles")]
+	[DataMember(Name = "available")]
 	public List<OrganizationDevicesSyslogServersRolesByNetworkItemAvailableRole> AvailableRoles { get; set; } = [];
 }

--- a/Meraki.Api/Data/OrganizationSplashTheme.cs
+++ b/Meraki.Api/Data/OrganizationSplashTheme.cs
@@ -12,4 +12,11 @@ public class OrganizationSplashTheme : NamedIdentifiedItem
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "themeAssets")]
 	public List<OrganizationSplashThemeThemeAsset> ThemeAssets { get; set; } = [];
+
+	/// <summary>
+	/// Whether this is a Meraki provided theme
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "isSystemTheme")]
+	public bool? IsSystemTheme { get; set; }
 }

--- a/Meraki.Api/Data/SamlIdp.cs
+++ b/Meraki.Api/Data/SamlIdp.cs
@@ -33,4 +33,18 @@ public class SamlIdp
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "sloLogoutUrl")]
 	public string SloLogoutUrl { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Dashboard will redirect users to this URL to log in again when their sessions expire.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "ssoLoginUrl")]
+	public string? SsoLoginUrl { get; set; }
+
+	/// <summary>
+	/// URL that is consuming SAML Identity Provider (IdP) for Meraki Vision Portal
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "visionConsumerUrl")]
+	public string? VisionConsumerUrl { get; set; }
 }

--- a/Meraki.Api/Data/WebhookAlertType.cs
+++ b/Meraki.Api/Data/WebhookAlertType.cs
@@ -21,114 +21,140 @@ public class WebhookAlertType
 	/// <summary>
 	/// Version
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "version")]
 	public string Version { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Shared secret
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "sharedSecret")]
 	public string SharedSecret { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Sent at
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "sentAt")]
 	public DateTime SentAt { get; set; }
 
 	/// <summary>
 	/// Alert id
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "alertId")]
 	public string AlertId { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Alert level
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "alertLevel")]
 	public string AlertLevel { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Occurred at
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "occurredAt")]
 	public DateTime OccurredAt { get; set; }
 
 	/// <summary>
 	/// Alert data
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "alertData")]
 	public List<string> AlertData { get; set; } = [];
 
 	/// <summary>
 	/// Organization id
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "organizationId")]
 	public string OrganizationId { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Organization name
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "organizationName")]
 	public string OrganizationName { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Organization url
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "organizationUrl")]
 	public string OrganizationUrl { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Device serial
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "deviceSerial")]
 	public string DeviceSerial { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Device mac
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "deviceMac")]
 	public string DeviceMac { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Device name
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "deviceName")]
 	public string DeviceName { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Device url
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "deviceUrl")]
 	public string DeviceUrl { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Device tags
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "deviceTags")]
 	public List<string> DeviceTags { get; set; } = [];
 
 	/// <summary>
 	/// Device model
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "deviceModel")]
 	public string DeviceModel { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Network id
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "networkId")]
 	public string NetworkId { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Network name
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "networkName")]
 	public string NetworkName { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Network URL
 	/// </summary>
+	[Obsolete("Never returned at this level: the Dashboard API sends it inside Example. Use Example instead. This property will be removed in a later release.")]
 	[DataMember(Name = "networkUrl")]
 	public string NetworkUrl { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Example alert payload for this alert type
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "example")]
+	public WebhookAlertTypeExample? Example { get; set; }
 }

--- a/Meraki.Api/Data/WebhookAlertTypeExample.cs
+++ b/Meraki.Api/Data/WebhookAlertTypeExample.cs
@@ -1,0 +1,138 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// An example payload for a webhook alert type
+/// </summary>
+[DataContract]
+public class WebhookAlertTypeExample
+{
+	/// <summary>Webhook payload version</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "version")]
+	public string? Version { get; set; }
+
+	/// <summary>Shared secret configured on the HTTP server</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "sharedSecret")]
+	public string? SharedSecret { get; set; }
+
+	/// <summary>When the webhook was sent</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "sentAt")]
+	public DateTime? SentAt { get; set; }
+
+	/// <summary>Alert ID</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "alertId")]
+	public string? AlertId { get; set; }
+
+	/// <summary>Alert type name</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "alertType")]
+	public string? AlertType { get; set; }
+
+	/// <summary>Alert type ID</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "alertTypeId")]
+	public string? AlertTypeId { get; set; }
+
+	/// <summary>Alert level</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "alertLevel")]
+	public string? AlertLevel { get; set; }
+
+	/// <summary>When the alert occurred</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "occurredAt")]
+	public DateTime? OccurredAt { get; set; }
+
+	/// <summary>Alert-type-specific data; its shape varies by alert type</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "alertData")]
+	public object? AlertData { get; set; }
+
+	/// <summary>Organization ID</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "organizationId")]
+	public string? OrganizationId { get; set; }
+
+	/// <summary>Organization name</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "organizationName")]
+	public string? OrganizationName { get; set; }
+
+	/// <summary>Organization URL</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "organizationUrl")]
+	public string? OrganizationUrl { get; set; }
+
+	/// <summary>Device serial</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "deviceSerial")]
+	public string? DeviceSerial { get; set; }
+
+	/// <summary>Device MAC address</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "deviceMac")]
+	public string? DeviceMac { get; set; }
+
+	/// <summary>Device name</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "deviceName")]
+	public string? DeviceName { get; set; }
+
+	/// <summary>Device URL</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "deviceUrl")]
+	public string? DeviceUrl { get; set; }
+
+	/// <summary>Device tags</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "deviceTags")]
+	public List<string>? DeviceTags { get; set; }
+
+	/// <summary>Device model</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "deviceModel")]
+	public string? DeviceModel { get; set; }
+
+	/// <summary>Network ID</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "networkId")]
+	public string? NetworkId { get; set; }
+
+	/// <summary>Network name</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "networkName")]
+	public string? NetworkName { get; set; }
+
+	/// <summary>Network URL</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "networkUrl")]
+	public string? NetworkUrl { get; set; }
+
+	/// <summary>Network tags</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "networkTags")]
+	public List<string>? NetworkTags { get; set; }
+
+	/// <summary>Network enrollment string</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "enrollmentString")]
+	public string? EnrollmentString { get; set; }
+
+	/// <summary>Network notes</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "notes")]
+	public string? Notes { get; set; }
+
+	/// <summary>Product types in the network</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "productTypes")]
+	public List<string>? ProductTypes { get; set; }
+
+	/// <summary>Encrypted ID</summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "encryptedId")]
+	public string? EncryptedId { get; set; }
+}


### PR DESCRIPTION
## Stacked on #416 → #415

Base is `fix/response-shape-defects`. Merge [#415](https://github.com/panoramicdata/Meraki.Api/pull/415) and [#416](https://github.com/panoramicdata/Meraki.Api/pull/416) first (merge commits), then retarget this to `main`. Changelog label `1.74.9` assumes that order.

## What

The first per-area batch from `gap-report-v1.74.0.md`: **30 Organizations-area members** the spec documents that the models lacked, across 17 classes. Types and read/write access come from the spec; XML docs are the spec descriptions.

| Kind | Count | Notes |
|---|---|---|
| Scalars on existing classes | 15 | `LoginSecurity.EnforceLockedIpSessions`, `NextUpgrade.Strategy`, `SamlIdp.SsoLoginUrl`/`.VisionConsumerUrl`, `OrganizationDevice.Imei`, … |
| Nested objects | 9 | 3 reuse existing product types (`FirmwareProducts.CampusGateway`, both `SwitchCatalyst`), 6 need new classes |
| New classes | 6 | `NextUpgradePredownload`, `NetworkStatusSummaryGroup`, `NetworkStatusSummaryPermissions`, `OrganizationAdaptivePolicyOverviewLimits`, `OrganizationAssuranceAlertsOverviewByTypeItemNetwork`, `WebhookAlertTypeExample` |

`NextUpgrade.Strategy` is a `string?` rather than an enum (`minimizeClientDowntime` / `minimizeUpgradeTime`) so an unlisted value can't break deserialization.

## Three corrections, not just additions

The diff surfaced three models in this area that never matched the API. Reading their old members always gave defaults, so changing them is breaking only in the type-system sense:

1. **`OrganizationAssuranceAlertsOverviewByTypeItem`** was a copy of the by-network item (`AlertCount`, `NetworkId`, `NetworkName`, `SeverityCounts`). The API sends `type`, `categoryType`, `severity`, `count`, `networkCount`, `networks`, `deviceTypes`, `deviceTags`, `lastAlertedAt`, `lastResolvedAt`. Rebuilt to that; `…SeverityCount` is `[Obsolete]`.
2. **`WebhookAlertType`** had the *example payload's* 19 fields flattened onto the alert type. The API sends `{alertTypeId, alertType, example}`. The flattened ones are `[Obsolete]` pointing at the new `Example`, which also carries five fields they never had.
3. **`OrganizationDevicesSyslogServersRolesByNetworkItem.AvailableRoles`** mapped `availableRoles`; the API sends `available`. DataMember fixed, C# name kept.

## Verification

```
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s), 6 pre-existing CS0618 warnings
Meraki.Api.Test (Data namespace)        Total: 30, Errors: 0, Failed: 0   (7 new in OrganizationsMemberTests)
Meraki.Api.Test (Workflows)             Total: 12, Errors: 0, Failed: 0
```

All 18 edited model files kept their BOM state and CRLF. No code outside `Data` referenced the corrected members.

## Next

Remaining areas in the report, largest first: SM (27), Appliance (25), Wireless (19), General (10), Camera (8), CellularGateway (7), Switch (7), Sensor (6), LiveTools (2), Licensing (1).
