### PR TITLE
feat: map the Systems Manager response members from the 1.74.0 gap report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ﻿# Changelog
 
+## 1.74.11
+
+- **Nineteen Systems Manager response members the v1.74.0 spec documents are now mapped**, the
+  second per-area batch from the gap report. `SmVppAccount` gains the thirteen fields the API
+  returns beyond `id` and `vppServiceToken` (`VppAccountId`, `ContentToken`, `Email`, `Name`,
+  `AllowedAdmins`, `NetworkIdAdmins`, `AssignableNetworks`, `AssignableNetworkIds`,
+  `VppLocationId`, `VppLocationName`, `LastSyncedAt`, `LastForceSyncedAt` and `ParsedToken`, a new
+  `SmVppAccountParsedToken`). `SmProfile.PayloadTypes` and `SmTrustedAccessConfig.TimeboundType`
+  are added.
+
+- **`ModifyNetworkSmDevicesTagsAsync` now returns `List<SmDevicesModifyTagsResponse>`** (breaking).
+  It was declared as `List<SmDevicesCheckinRequest>`, the *request* type, whose members (`ids`,
+  `scope`, `serials`, `wifiMacs`) never appear in the response; each returned device is
+  `{id, serial, wifiMac, tags}` and previously came back as an empty object. `CheckinNetworkSmDevicesAsync`
+  and `LockNetworkSmDevicesAsync` keep returning the request type, because the API's `{ids}`
+  response does bind to it. Regression tests are in `Meraki.Api.Test.Data.SmMemberTests`.
+
 ## 1.74.9
 
 - **Thirty Organizations-area response members the v1.74.0 spec documents are now mapped**, the

--- a/Meraki.Api.Test/Data/SmMemberTests.cs
+++ b/Meraki.Api.Test/Data/SmMemberTests.cs
@@ -1,0 +1,75 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for Systems Manager response members the v1.74.0 OpenAPI spec documents that
+/// the models lacked. Each payload has the shape the spec documents, and is deserialized with the
+/// settings <see cref="JsonMissingMemberHandling.ThrowOnError"/> uses so an unmapped field fails
+/// the test rather than being dropped.
+/// </summary>
+public class SmMemberTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// GET /organizations/{organizationId}/sm/vppAccounts/{vppAccountId}
+	[Fact]
+	public void Deserialize_SmVppAccount_MapsEveryDocumentedField()
+	{
+		var account = Deserialize<SmVppAccount>("""
+			{ "vppAccountId": "1", "contentToken": "token", "email": "admin@example.com", "name": "Example VPP", "allowedAdmins": "All admins", "networkIdAdmins": "", "assignableNetworks": "All networks", "assignableNetworkIds": [ "N_1" ], "vppLocationId": "L_1", "vppLocationName": "Example", "lastSyncedAt": "2026-09-09T10:00:00Z", "lastForceSyncedAt": null, "parsedToken": { "orgName": "Example", "hashedToken": "abc", "expiresAt": "2027-01-01T00:00:00Z" }, "id": "1", "vppServiceToken": "token" }
+			""");
+
+		_ = account.VppAccountId.Should().Be("1");
+		_ = account.AssignableNetworkIds.Should().ContainSingle();
+		_ = account.ParsedToken!.OrgName.Should().Be("Example");
+		_ = account.LastForceSyncedAt.Should().BeNull();
+	}
+
+	// GET /networks/{networkId}/sm/profiles
+	[Fact]
+	public void Deserialize_SmProfile_MapsPayloadTypes()
+	{
+		var profile = Deserialize<SmProfile>("""
+			{ "id": "1", "name": "Wi-Fi", "description": "", "scope": "all", "tags": [], "payloadTypes": [ "com.apple.wifi.managed" ] }
+			""");
+
+		_ = profile.PayloadTypes.Should().ContainSingle();
+	}
+
+	// GET /networks/{networkId}/sm/trustedAccessConfigs
+	[Fact]
+	public void Deserialize_SmTrustedAccessConfig_MapsTimeboundType()
+	{
+		var config = Deserialize<SmTrustedAccessConfig>("""
+			{ "id": "1", "ssidName": "Guest", "name": "Guests", "scope": "all", "tags": [], "timeboundType": "static", "sendExpirationEmails": false, "notifyTimeBeforeAccessEnds": 0, "additionalEmailText": "", "accessStartAt": "2026-09-01T00:00:00Z", "accessEndAt": "2026-09-30T00:00:00Z" }
+			""");
+
+		_ = config.TimeboundType.Should().Be("static");
+	}
+
+	// POST /networks/{networkId}/sm/devices/modifyTags - previously declared as returning the request
+	// type, none of whose members the response contains.
+	[Fact]
+	public void Deserialize_SmDevicesModifyTagsResponse_MapsReturnedDevice()
+	{
+		var devices = Deserialize<List<SmDevicesModifyTagsResponse>>("""
+			[ { "id": "1", "serial": "Q2XX-ABCD-1234", "wifiMac": "00:11:22:33:44:55", "tags": [ "sales" ] } ]
+			""");
+
+		_ = devices.Should().ContainSingle().Which.Tags.Should().ContainSingle();
+	}
+}

--- a/Meraki.Api/Data/SmDevicesModifyTagsResponse.cs
+++ b/Meraki.Api/Data/SmDevicesModifyTagsResponse.cs
@@ -1,0 +1,36 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// A device whose tags were modified by a bulk Systems Manager tag change
+/// </summary>
+[DataContract]
+public class SmDevicesModifyTagsResponse
+{
+	/// <summary>
+	/// The Meraki Id of the device record.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "id")]
+	public string? Id { get; set; }
+
+	/// <summary>
+	/// The device serial.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "serial")]
+	public string? Serial { get; set; }
+
+	/// <summary>
+	/// The MAC of the device.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "wifiMac")]
+	public string? WifiMac { get; set; }
+
+	/// <summary>
+	/// An array of tags associated with the device.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "tags")]
+	public List<string> Tags { get; set; } = [];
+}

--- a/Meraki.Api/Data/SmProfile.cs
+++ b/Meraki.Api/Data/SmProfile.cs
@@ -33,4 +33,11 @@ public class SmProfile : NamedIdentifiedItem
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "targetGroupId")]
 	public string? TargetGroupId { get; set; }
+
+	/// <summary>
+	/// Payloads in the profile.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "payloadTypes")]
+	public List<string> PayloadTypes { get; set; } = [];
 }

--- a/Meraki.Api/Data/SmTrustedAccessConfig.cs
+++ b/Meraki.Api/Data/SmTrustedAccessConfig.cs
@@ -59,4 +59,11 @@ public class SmTrustedAccessConfig : NamedIdentifiedItem
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "additionalEmailText")]
 	public string? AdditionalEmailText { get; set; }
+
+	/// <summary>
+	/// Type of access period, either a static range or a dynamic period
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "timeboundType")]
+	public string? TimeboundType { get; set; }
 }

--- a/Meraki.Api/Data/SmVppAccount.cs
+++ b/Meraki.Api/Data/SmVppAccount.cs
@@ -18,4 +18,95 @@ public class SmVppAccount
 	/// </summary>
 	[DataMember(Name = "vppServiceToken")]
 	public string VppServiceToken { get; set; } = string.Empty;
+
+	/// <summary>
+	/// The id of the VPP Account
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "vppAccountId")]
+	public string? VppAccountId { get; set; }
+
+	/// <summary>
+	/// The VPP content token
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "contentToken")]
+	public string? ContentToken { get; set; }
+
+	/// <summary>
+	/// The email address associated with the VPP account
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "email")]
+	public string? Email { get; set; }
+
+	/// <summary>
+	/// The name of the VPP account
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "name")]
+	public string? Name { get; set; }
+
+	/// <summary>
+	/// The allowed admins for the VPP account
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "allowedAdmins")]
+	public string? AllowedAdmins { get; set; }
+
+	/// <summary>
+	/// The network IDs of the admins for the VPP account
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "networkIdAdmins")]
+	public string? NetworkIdAdmins { get; set; }
+
+	/// <summary>
+	/// The assignable networks for the VPP account
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "assignableNetworks")]
+	public string? AssignableNetworks { get; set; }
+
+	/// <summary>
+	/// The network IDs of the assignable networks for the VPP account
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "assignableNetworkIds")]
+	public List<string> AssignableNetworkIds { get; set; } = [];
+
+	/// <summary>
+	/// The VPP location ID
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "vppLocationId")]
+	public string? VppLocationId { get; set; }
+
+	/// <summary>
+	/// The VPP location name
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "vppLocationName")]
+	public string? VppLocationName { get; set; }
+
+	/// <summary>
+	/// The last time the VPP account was synced
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "lastSyncedAt")]
+	public DateTime? LastSyncedAt { get; set; }
+
+	/// <summary>
+	/// The last time the VPP account was force synced
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "lastForceSyncedAt")]
+	public DateTime? LastForceSyncedAt { get; set; }
+
+	/// <summary>
+	/// The parsed VPP service token
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "parsedToken")]
+	public SmVppAccountParsedToken? ParsedToken { get; set; }
 }

--- a/Meraki.Api/Data/SmVppAccountParsedToken.cs
+++ b/Meraki.Api/Data/SmVppAccountParsedToken.cs
@@ -1,0 +1,29 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The parsed VPP service token
+/// </summary>
+[DataContract]
+public class SmVppAccountParsedToken
+{
+	/// <summary>
+	/// The organization name in the token
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "orgName")]
+	public string? OrgName { get; set; }
+
+	/// <summary>
+	/// The hashed token
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "hashedToken")]
+	public string? HashedToken { get; set; }
+
+	/// <summary>
+	/// When the token expires
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "expiresAt")]
+	public DateTime? ExpiresAt { get; set; }
+}

--- a/Meraki.Api/Interfaces/Products/Sm/ISmDevices.cs
+++ b/Meraki.Api/Interfaces/Products/Sm/ISmDevices.cs
@@ -69,7 +69,7 @@ public interface ISmDevices
 	/// <param name="modifyNetworkSmDevicesTags"></param>
 	/// <param name="cancellationToken"></param>
 	[Post("/networks/{networkId}/sm/devices/modifyTags")]
-	Task<List<SmDevicesCheckinRequest>> ModifyNetworkSmDevicesTagsAsync(
+	Task<List<SmDevicesModifyTagsResponse>> ModifyNetworkSmDevicesTagsAsync(
 		string networkId,
 		[Body] ModifyNetworkDeviceTags modifyNetworkSmDevicesTags,
 		CancellationToken cancellationToken = default


### PR DESCRIPTION
## Stacked on #417 → #416 → #415

Base is `feat/map-organizations-members`. Merge [#415](https://github.com/panoramicdata/Meraki.Api/pull/415), [#416](https://github.com/panoramicdata/Meraki.Api/pull/416) and [#417](https://github.com/panoramicdata/Meraki.Api/pull/417) first (merge commits), then retarget this to `main`. Changelog label `1.74.11` assumes that order.

## What

The second per-area batch from `gap-report-v1.74.0.md`: **19 Systems Manager members** the spec documents that the models lacked.

| Model | Added |
|---|---|
| `SmVppAccount` | 13 fields the API returns beyond `id`/`vppServiceToken`, incl. `ParsedToken` (new `SmVppAccountParsedToken`: `OrgName`, `HashedToken`, `ExpiresAt`) |
| `SmProfile` | `PayloadTypes` |
| `SmTrustedAccessConfig` | `TimeboundType` |

## One correction (breaking)

`ModifyNetworkSmDevicesTagsAsync` was declared as `Task<List<SmDevicesCheckinRequest>>` — the *request* type. The API returns `[{id, serial, wifiMac, tags}]`, none of which the request type has, so every device came back as an empty object. It now returns `Task<List<SmDevicesModifyTagsResponse>>`.

`CheckinNetworkSmDevicesAsync` and `LockNetworkSmDevicesAsync` also return the request type, but their `{ids}` response does bind to it, so they are left alone.

## Not in this PR

Seven `DeviceLiveTools*` members my area filter caught belong to LiveTools/General and will land with that batch.

## Verification

```
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s), 6 pre-existing CS0618 warnings
Meraki.Api.Test (Data namespace)        Total: 34, Errors: 0, Failed: 0   (4 new in SmMemberTests)
Meraki.Api.Test (Workflows)             Total: 12, Errors: 0, Failed: 0
```

Edited files kept their BOM state. No code outside `Interfaces`/`Data` referenced the changed method.
