### PR TITLE
feat: map the Appliance response members from the 1.74.0 gap report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ﻿# Changelog
 
+## 1.74.13
+
+- **Eighteen Appliance response members the v1.74.0 spec documents are now mapped**, the third
+  per-area batch from the gap report. Security Group Tag settings on `AppliancePort.Sgt`, `Vlan.Sgt`
+  and `SiteToSiteVpn.Sgt` (new `AppliancePortSgt`, `VlanSgt`, `SiteToSiteVpnSgt`); VRF settings on
+  `LanConfiguration.Vrf`, `Neighbor.Vrf` and `TrafficUplinkPreference.Vrf` (reusing `VlanVrf`, the
+  same `{id, name}` shape); `SiteToSiteVpn.HostTranslations` (new `SiteToSiteVpnHostTranslation`
+  and `SiteToSiteVpnHostTranslationAddress`); `ThirdPartyVpnPeer.EcmpUplinkConfigs` (new
+  `ThirdPartyVpnPeerEcmpUplinkConfig` and `ThirdPartyVpnPeerEcmpUplinkConfigEbgpNeighbor`);
+  `NetworkUmbrellaAccountConnectResponse.Umbrella` (new `NetworkUmbrellaAccountConnectResponseUmbrella`
+  and `NetworkUmbrellaAccountConnectResponseUmbrellaOrganization`); `StaticRoute.IpVersion`;
+  `ThirdPartyVpnPeerEbgpNeighbor.ReceiveLimit`.
+
+- **Two more members that could never bind are corrected** (breaking in the type-system sense
+  only, since they always came back empty):
+  - `VpnStatus.ThirdPartyVpnPeers` was a `List<ThirdPartyVpnPeers>`, the *configuration* wrapper
+    whose only member is `peers`. Each status entry is `{name, publicIp, reachability}`; the list is
+    now `List<VpnStatusThirdPartyVpnPeer>`.
+  - `UpdateOrganizationApplianceDnsLocalRecordAsync` returned `OrganizationApplianceDnsLocalRecordsProfile`
+    (only `id`); the API returns the record, so it now returns
+    `OrganizationApplianceDnsLocalRecordsResponse` like the create and list methods.
+
+  Regression tests are in `Meraki.Api.Test.Data.ApplianceMemberTests`.
+
 ## 1.74.11
 
 - **Nineteen Systems Manager response members the v1.74.0 spec documents are now mapped**, the

--- a/Meraki.Api.Test/Data/ApplianceMemberTests.cs
+++ b/Meraki.Api.Test/Data/ApplianceMemberTests.cs
@@ -1,0 +1,108 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for Appliance response members the v1.74.0 OpenAPI spec documents that the
+/// models lacked. Each payload has the shape the spec documents, and is deserialized with the
+/// settings <see cref="JsonMissingMemberHandling.ThrowOnError"/> uses so an unmapped field fails
+/// the test rather than being dropped.
+/// </summary>
+public class ApplianceMemberTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// GET /networks/{networkId}/appliance/ports/{portId}
+	[Fact]
+	public void Deserialize_AppliancePort_MapsSgt()
+	{
+		var port = Deserialize<AppliancePort>("""
+			{ "number": 4, "enabled": true, "type": "access", "dropUntaggedTraffic": false, "vlan": 10, "allowedVlans": "all", "accessPolicy": "open", "sgt": { "id": 1234, "enabled": true } }
+			""");
+
+		_ = port.Sgt!.Id.Should().Be(1234);
+		_ = port.Sgt.Enabled.Should().BeTrue();
+	}
+
+	// GET /networks/{networkId}/appliance/vpn/siteToSiteVpn
+	[Fact]
+	public void Deserialize_SiteToSiteVpn_MapsSgtAndHostTranslations()
+	{
+		var vpn = Deserialize<SiteToSiteVpn>("""
+			{ "mode": "spoke", "hubs": [], "subnets": [], "sgt": { "enabled": false }, "hostTranslations": [ { "name": "web", "local": { "address": "10.0.0.5" }, "remote": { "address": "192.0.2.5" } } ] }
+			""");
+
+		_ = vpn.Sgt!.Enabled.Should().BeFalse();
+		_ = vpn.HostTranslations.Should().ContainSingle().Which.Remote!.Address.Should().Be("192.0.2.5");
+	}
+
+	// GET /networks/{networkId}/appliance/singleLan
+	[Fact]
+	public void Deserialize_LanConfiguration_MapsVrf()
+	{
+		var lan = Deserialize<LanConfiguration>("""
+			{ "subnet": "10.0.0.0/24", "applianceIp": "10.0.0.1", "vrf": { "id": "1", "name": "Default" } }
+			""");
+
+		_ = lan.Vrf!.Name.Should().Be("Default");
+	}
+
+	// peers[] from GET /organizations/{organizationId}/appliance/vpn/thirdPartyVPNPeers
+	[Fact]
+	public void Deserialize_ThirdPartyVpnPeer_MapsEcmpUplinkConfigsAndReceiveLimit()
+	{
+		var peer = Deserialize<ThirdPartyVpnPeer>("""
+			{ "peerId": "1", "name": "DC", "publicIp": "192.0.2.10", "privateSubnets": [ "10.1.0.0/16" ], "ikeVersion": "2", "ebgpNeighbor": { "neighborId": 1, "neighborIp": "169.254.0.2", "ipVersion": 4, "remoteAsNumber": 65001, "ebgpHoldTimer": 180, "ebgpMultihop": 2, "sourceIp": "169.254.0.1", "receiveLimit": 100, "pathPrepend": [], "multiExitDiscriminator": 1, "weight": 10 }, "ecmpUplinkConfigs": [ { "id": "1", "wan": "wan1", "privateSubnets": [ "10.1.0.0/16" ], "ebgpNeighbor": { "neighborIp": "169.254.0.2", "sourceIp": "169.254.0.1" } } ] }
+			""");
+
+		_ = peer.EbgpNeighbor!.ReceiveLimit.Should().Be(100);
+		_ = peer.EcmpUplinkConfigs.Should().ContainSingle().Which.EbgpNeighbor!.NeighborIp.Should().Be("169.254.0.2");
+	}
+
+	// items[] from GET /organizations/{organizationId}/appliance/vpn/statuses - previously typed as
+	// the configuration wrapper, whose only member is "peers".
+	[Fact]
+	public void Deserialize_VpnStatus_MapsThirdPartyVpnPeerStatuses()
+	{
+		var status = Deserialize<VpnStatus>("""
+			{ "networkId": "N_1", "networkName": "HQ", "deviceSerial": "Q2XX-ABCD-1234", "deviceStatus": "online", "uplinks": [], "vpnMode": "hub", "exportedSubnets": [], "merakiVpnPeers": [], "thirdPartyVpnPeers": [ { "name": "DC", "publicIp": "192.0.2.10", "reachability": "reachable" } ] }
+			""");
+
+		_ = status.ThirdPartyVpnPeers.Should().ContainSingle().Which.Reachability.Should().Be("reachable");
+	}
+
+	// POST /networks/{networkId}/appliance/umbrella/account/connect
+	[Fact]
+	public void Deserialize_NetworkUmbrellaAccountConnectResponse_MapsUmbrella()
+	{
+		var response = Deserialize<NetworkUmbrellaAccountConnectResponse>("""
+			{ "umbrellaOrganizationId": "1", "umbrella": { "organization": { "id": "1" } } }
+			""");
+
+		_ = response.Umbrella!.Organization!.Id.Should().Be("1");
+	}
+
+	// GET /networks/{networkId}/appliance/staticRoutes/{staticRouteId}
+	[Fact]
+	public void Deserialize_StaticRoute_MapsIpVersion()
+	{
+		var route = Deserialize<StaticRoute>("""
+			{ "id": "1", "ipVersion": 4, "networkId": "N_1", "enabled": true, "name": "To DC", "subnet": "10.1.0.0/16", "gatewayIp": "10.0.0.254" }
+			""");
+
+		_ = route.IpVersion.Should().Be(4);
+	}
+}

--- a/Meraki.Api/Data/AppliancePort.cs
+++ b/Meraki.Api/Data/AppliancePort.cs
@@ -69,4 +69,11 @@ public class AppliancePort
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "adaptivePolicyGroupId")]
 	public object? AdaptivePolicyGroupId { get; set; }
+
+	/// <summary>
+	/// Security Group Tag settings for the port.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "sgt")]
+	public AppliancePortSgt? Sgt { get; set; }
 }

--- a/Meraki.Api/Data/AppliancePortSgt.cs
+++ b/Meraki.Api/Data/AppliancePortSgt.cs
@@ -1,0 +1,22 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Security Group Tag settings for an appliance port
+/// </summary>
+[DataContract]
+public class AppliancePortSgt
+{
+	/// <summary>
+	/// Adaptive policy group ID this port is assigned to.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "id")]
+	public int? Id { get; set; }
+
+	/// <summary>
+	/// Whether or not Peer SGT is enabled for traffic through this port.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/LanConfiguration.cs
+++ b/Meraki.Api/Data/LanConfiguration.cs
@@ -90,4 +90,11 @@ public class LanConfiguration
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "mandatoryDhcp")]
 	public MandatoryDhcp MandatoryDhcp { get; set; } = new();
+
+	/// <summary>
+	/// VRF configuration on the single LAN
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "vrf")]
+	public VlanVrf? Vrf { get; set; }
 }

--- a/Meraki.Api/Data/Neighbor.cs
+++ b/Meraki.Api/Data/Neighbor.cs
@@ -117,4 +117,11 @@ public class Neighbor
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "communityOut")]
 	public string? CommunityOut { get; set; }
+
+	/// <summary>
+	/// VRF settings for the neighbor
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "vrf")]
+	public VlanVrf? Vrf { get; set; }
 }

--- a/Meraki.Api/Data/NetworkUmbrellaAccountConnectResponse.cs
+++ b/Meraki.Api/Data/NetworkUmbrellaAccountConnectResponse.cs
@@ -12,4 +12,11 @@ public class NetworkUmbrellaAccountConnectResponse
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "umbrellaOrganizationId")]
 	public string UmbrellaOrganizationId { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Umbrella configuration
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "umbrella")]
+	public NetworkUmbrellaAccountConnectResponseUmbrella? Umbrella { get; set; }
 }

--- a/Meraki.Api/Data/NetworkUmbrellaAccountConnectResponseUmbrella.cs
+++ b/Meraki.Api/Data/NetworkUmbrellaAccountConnectResponseUmbrella.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Umbrella configuration returned when connecting an Umbrella account
+/// </summary>
+[DataContract]
+public class NetworkUmbrellaAccountConnectResponseUmbrella
+{
+	/// <summary>
+	/// Organization details
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "organization")]
+	public NetworkUmbrellaAccountConnectResponseUmbrellaOrganization? Organization { get; set; }
+}

--- a/Meraki.Api/Data/NetworkUmbrellaAccountConnectResponseUmbrellaOrganization.cs
+++ b/Meraki.Api/Data/NetworkUmbrellaAccountConnectResponseUmbrellaOrganization.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The Umbrella organization connected to a network
+/// </summary>
+[DataContract]
+public class NetworkUmbrellaAccountConnectResponseUmbrellaOrganization
+{
+	/// <summary>
+	/// The Umbrella organization ID
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "id")]
+	public string? Id { get; set; }
+}

--- a/Meraki.Api/Data/SiteToSiteVpn.cs
+++ b/Meraki.Api/Data/SiteToSiteVpn.cs
@@ -40,4 +40,18 @@ public class SiteToSiteVpn
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "subnet")]
 	public SiteToSiteVpnSubnet? Subnet { get; set; }
+
+	/// <summary>
+	/// Security Group Tag settings for the VPN peer.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "sgt")]
+	public SiteToSiteVpnSgt? Sgt { get; set; }
+
+	/// <summary>
+	/// The list of VPN host translations. Host translations are supported starting from MX firmware version 26.1.2
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "hostTranslations")]
+	public List<SiteToSiteVpnHostTranslation>? HostTranslations { get; set; }
 }

--- a/Meraki.Api/Data/SiteToSiteVpnHostTranslation.cs
+++ b/Meraki.Api/Data/SiteToSiteVpnHostTranslation.cs
@@ -1,0 +1,29 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// A VPN host translation. Host translations are supported starting from MX firmware version 26.1.2
+/// </summary>
+[DataContract]
+public class SiteToSiteVpnHostTranslation
+{
+	/// <summary>
+	/// Name of the host translation
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "name")]
+	public string? Name { get; set; }
+
+	/// <summary>
+	/// Configuration of the local address of the translated host.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "local")]
+	public SiteToSiteVpnHostTranslationAddress? Local { get; set; }
+
+	/// <summary>
+	/// Configuration of the remote address of the translated host.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "remote")]
+	public SiteToSiteVpnHostTranslationAddress? Remote { get; set; }
+}

--- a/Meraki.Api/Data/SiteToSiteVpnHostTranslationAddress.cs
+++ b/Meraki.Api/Data/SiteToSiteVpnHostTranslationAddress.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// One side of a VPN host translation
+/// </summary>
+[DataContract]
+public class SiteToSiteVpnHostTranslationAddress
+{
+	/// <summary>
+	/// The IP address of the translated host on this side
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "address")]
+	public string? Address { get; set; }
+}

--- a/Meraki.Api/Data/SiteToSiteVpnSgt.cs
+++ b/Meraki.Api/Data/SiteToSiteVpnSgt.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Security Group Tag settings for the VPN peer
+/// </summary>
+[DataContract]
+public class SiteToSiteVpnSgt
+{
+	/// <summary>
+	/// Whether Security Group Tagging is enabled for the VPN peer
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/StaticRoute.cs
+++ b/Meraki.Api/Data/StaticRoute.cs
@@ -35,4 +35,11 @@ public class StaticRoute : StaticRouteUpdateRequest
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "vpn")]
 	public StaticRouteVpn? Vpn { get; set; }
+
+	/// <summary>
+	/// IP protocol version
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "ipVersion")]
+	public int? IpVersion { get; set; }
 }

--- a/Meraki.Api/Data/ThirdPartyVpnPeer.cs
+++ b/Meraki.Api/Data/ThirdPartyVpnPeer.cs
@@ -124,4 +124,11 @@ public class ThirdPartyVpnPeer : NamedItem
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "ebgpNeighbor")]
 	public ThirdPartyVpnPeerEbgpNeighbor? EbgpNeighbor { get; set; }
+
+	/// <summary>
+	/// [optional] The ECMP per-uplink BGP-over-IPsec configuration for the VPN peer.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "ecmpUplinkConfigs")]
+	public List<ThirdPartyVpnPeerEcmpUplinkConfig>? EcmpUplinkConfigs { get; set; }
 }

--- a/Meraki.Api/Data/ThirdPartyVpnPeerEbgpNeighbor.cs
+++ b/Meraki.Api/Data/ThirdPartyVpnPeerEbgpNeighbor.cs
@@ -78,4 +78,11 @@ public class ThirdPartyVpnPeerEbgpNeighbor
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "pathPrepend")]
 	public List<int>? PathPrepend { get; set; }
+
+	/// <summary>
+	/// Maximum number of prefixes accepted from the remote peer. Must be an integer between 0 and 2147483647.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "receiveLimit")]
+	public int? ReceiveLimit { get; set; }
 }

--- a/Meraki.Api/Data/ThirdPartyVpnPeerEcmpUplinkConfig.cs
+++ b/Meraki.Api/Data/ThirdPartyVpnPeerEcmpUplinkConfig.cs
@@ -1,0 +1,36 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// An ECMP per-uplink BGP-over-IPsec configuration for a third-party VPN peer
+/// </summary>
+[DataContract]
+public class ThirdPartyVpnPeerEcmpUplinkConfig
+{
+	/// <summary>
+	/// ID of the ECMP uplink configuration
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "id")]
+	public string? Id { get; set; }
+
+	/// <summary>
+	/// The WAN uplink associated with this ECMP configuration.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "wan")]
+	public string? Wan { get; set; }
+
+	/// <summary>
+	/// The private subnets associated with this ECMP uplink configuration.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "privateSubnets")]
+	public List<string> PrivateSubnets { get; set; } = [];
+
+	/// <summary>
+	/// [optional] The eBGP neighbor configuration associated with this ECMP uplink configuration.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "ebgpNeighbor")]
+	public ThirdPartyVpnPeerEcmpUplinkConfigEbgpNeighbor? EbgpNeighbor { get; set; }
+}

--- a/Meraki.Api/Data/ThirdPartyVpnPeerEcmpUplinkConfigEbgpNeighbor.cs
+++ b/Meraki.Api/Data/ThirdPartyVpnPeerEcmpUplinkConfigEbgpNeighbor.cs
@@ -1,0 +1,22 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The eBGP neighbor of an ECMP uplink configuration
+/// </summary>
+[DataContract]
+public class ThirdPartyVpnPeerEcmpUplinkConfigEbgpNeighbor
+{
+	/// <summary>
+	/// The IP address of the eBGP neighbor
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "neighborIp")]
+	public string? NeighborIp { get; set; }
+
+	/// <summary>
+	/// The source IP address used for the eBGP session
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "sourceIp")]
+	public string? SourceIp { get; set; }
+}

--- a/Meraki.Api/Data/TrafficUplinkPreference.cs
+++ b/Meraki.Api/Data/TrafficUplinkPreference.cs
@@ -33,4 +33,11 @@ public class TrafficUplinkPreference
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "performanceClass")]
 	public PerformanceClass? PerformanceClass { get; set; }
+
+	/// <summary>
+	/// VRF settings for this uplink preference rule. Only included when VRF is enabled for the organization.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "vrf")]
+	public VlanVrf? Vrf { get; set; }
 }

--- a/Meraki.Api/Data/Vlan.cs
+++ b/Meraki.Api/Data/Vlan.cs
@@ -182,4 +182,11 @@ public class Vlan : NamedIdentifiedItem
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "uplinks")]
 	public List<VlanUplink>? Uplinks { get; set; }
+
+	/// <summary>
+	/// Security Group Tag settings for the VLAN.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "sgt")]
+	public VlanSgt? Sgt { get; set; }
 }

--- a/Meraki.Api/Data/VlanSgt.cs
+++ b/Meraki.Api/Data/VlanSgt.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Security Group Tag settings for the VLAN
+/// </summary>
+[DataContract]
+public class VlanSgt
+{
+	/// <summary>
+	/// The Security Group Tag ID
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "id")]
+	public int? Id { get; set; }
+}

--- a/Meraki.Api/Data/VpnStatus.cs
+++ b/Meraki.Api/Data/VpnStatus.cs
@@ -58,5 +58,5 @@ public class VpnStatus
 	/// Third party VPN peers
 	/// </summary>
 	[DataMember(Name = "thirdPartyVpnPeers")]
-	public List<ThirdPartyVpnPeers> ThirdPartyVpnPeers { get; set; } = [];
+	public List<VpnStatusThirdPartyVpnPeer> ThirdPartyVpnPeers { get; set; } = [];
 }

--- a/Meraki.Api/Data/VpnStatusThirdPartyVpnPeer.cs
+++ b/Meraki.Api/Data/VpnStatusThirdPartyVpnPeer.cs
@@ -1,0 +1,29 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The status of a third-party VPN peer as reported on an appliance VPN status
+/// </summary>
+[DataContract]
+public class VpnStatusThirdPartyVpnPeer
+{
+	/// <summary>
+	/// Name of the peer
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "name")]
+	public string? Name { get; set; }
+
+	/// <summary>
+	/// Public IP of the peer
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "publicIp")]
+	public string? PublicIp { get; set; }
+
+	/// <summary>
+	/// Reachability
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "reachability")]
+	public string? Reachability { get; set; }
+}

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationsApplianceDnsLocalRecords.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationsApplianceDnsLocalRecords.cs
@@ -43,7 +43,7 @@ public interface IOrganizationsApplianceDnsLocalRecord
 	/// <returns></returns>
 	[ApiOperationId("updateOrganizationApplianceDnsLocalRecord")]
 	[Put("/organizations/{organizationId}/appliance/dns/local/records/{recordId}")]
-	Task<OrganizationApplianceDnsLocalRecordsProfile> UpdateOrganizationApplianceDnsLocalRecordAsync(
+	Task<OrganizationApplianceDnsLocalRecordsResponse> UpdateOrganizationApplianceDnsLocalRecordAsync(
 		string organizationId,
 		string recordId,
 		OrganizationApplianceDnsLocalRecordsUpdateRequest request,


### PR DESCRIPTION
## Stacked on #418 → #417 → #416 → #415

Base is `feat/map-sm-members`. Merge the chain in order with merge commits, then retarget this to `main`. Changelog label `1.74.13` assumes that.

## What

Third per-area batch from `gap-report-v1.74.0.md`: **18 Appliance members** the spec documents that the models lacked, across 12 classes.

| Member | Type |
|---|---|
| `AppliancePort.Sgt`, `Vlan.Sgt`, `SiteToSiteVpn.Sgt` | new `AppliancePortSgt` `{id, enabled}`, `VlanSgt` `{id}`, `SiteToSiteVpnSgt` `{enabled}` — the three differ in the spec |
| `LanConfiguration.Vrf`, `Neighbor.Vrf`, `TrafficUplinkPreference.Vrf` | existing `VlanVrf` `{id, name}` — identical shape, reused rather than triplicated |
| `SiteToSiteVpn.HostTranslations` | new `SiteToSiteVpnHostTranslation` `{name, local, remote}` + `…Address` |
| `ThirdPartyVpnPeer.EcmpUplinkConfigs` | new `ThirdPartyVpnPeerEcmpUplinkConfig` `{id, wan, privateSubnets, ebgpNeighbor}` + `…EbgpNeighbor` |
| `NetworkUmbrellaAccountConnectResponse.Umbrella` | new `…Umbrella` → `…Organization` `{id}` |
| `StaticRoute.IpVersion`, `ThirdPartyVpnPeerEbgpNeighbor.ReceiveLimit` | `int?` |

Access follows the spec: read/update where the member is on a PUT body, read-only otherwise.

## Two corrections (breaking in the type-system sense; both always came back empty)

1. **`VpnStatus.ThirdPartyVpnPeers`** was `List<ThirdPartyVpnPeers>` — the *configuration* wrapper (`{peers}`), so each status entry deserialized to an object with an empty `Peers`. The API sends `{name, publicIp, reachability}`; now `List<VpnStatusThirdPartyVpnPeer>`.
2. **`UpdateOrganizationApplianceDnsLocalRecordAsync`** returned `OrganizationApplianceDnsLocalRecordsProfile` (`{id}` only). The API returns the record; it now returns `OrganizationApplianceDnsLocalRecordsResponse`, matching the create and list methods #416 fixed.

## Verification

```
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s), 6 pre-existing CS0618 warnings
Meraki.Api.Test (Data namespace)        Total: 41, Errors: 0, Failed: 0   (7 new in ApplianceMemberTests)
Meraki.Api.Test (Workflows)             Total: 12, Errors: 0, Failed: 0
```

All edited files kept their BOM state and line endings. No code outside `Interfaces`/`Data` referenced the changed members.
