### PR TITLE
feat: map the Wireless response members from the 1.74.0 gap report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ﻿# Changelog
 
+## 1.74.15
+
+- **Nineteen Wireless response members the v1.74.0 spec documents are now mapped**, the fourth
+  per-area batch from the gap report: `Ssid.CampusGateway` (new `SsidCampusGateway` and
+  `SsidCampusGatewayCluster`) and `Ssid.WlanIdentifier`; `WirelessRfProfileCreateUpdateRequest.Dot11be`
+  (see below); `ElectronicShelfLabelSettingsNetwork.Sepioo` (new
+  `ElectronicShelfLabelSettingsNetworkSepioo`); `AirMarshal.Encryption`, `.Manufacturers` and
+  `.Types`; `Gre.ClientIsolation`; `NaiRealm.Name`; `FailedConnection.Radio`;
+  `DevicesWirelessZigbeeEnrollmentsDetailed.EnrollmentStartedAt`; `ConnectivityEvents.SsidNumber`;
+  `SsidsStatusesByDeviceItemBasicServiceSetRadio.Index`; and on `Wifi` (channel utilization) the
+  API's current names `startTime`, `endTime`, `utilizationTotal`, `utilization80211` and
+  `utilizationNon80211` alongside the legacy `start_ts`/`end_ts`/`utilization`/`wifi`/`non_wifi`
+  members, which are kept because it is not known which set the API sends today.
+
+- **Two misspelt member names corrected**, each of which meant the property never bound:
+  `OrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalGetResponse.Meta` was
+  mapped to `name` instead of `meta`; and `WirelessRfProfileCreateUpdateRequest.Be` was mapped to
+  `be` where the API sends `dot11be`, so it is now `Dot11be` and `WirelessRfProfileBe` gains the
+  spec's `Mode` and `Ssids` (per-group settings, new `WirelessRfProfileBeSsids` and
+  `WirelessRfProfileBeSsidGroup`). Also, `DevicesWirelessZigbeeEnrollmentsDetailed` had a property
+  called `EnrollmentStartedAt` that was bound to `enrollmentStatus`; it is renamed `EnrollmentStatus`
+  and the new `EnrollmentStartedAt` is the real timestamp. Regression tests are in
+  `Meraki.Api.Test.Data.WirelessMemberTests`.
+
 ## 1.74.13
 
 - **Eighteen Appliance response members the v1.74.0 spec documents are now mapped**, the third

--- a/Meraki.Api.Test/Data/WirelessMemberTests.cs
+++ b/Meraki.Api.Test/Data/WirelessMemberTests.cs
@@ -1,0 +1,112 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for Wireless response members the v1.74.0 OpenAPI spec documents that the
+/// models lacked. Each payload has the shape the spec documents, and is deserialized with the
+/// settings <see cref="JsonMissingMemberHandling.ThrowOnError"/> uses so an unmapped field fails
+/// the test rather than being dropped.
+/// </summary>
+public class WirelessMemberTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// GET /networks/{networkId}/wireless/ssids/{number}
+	[Fact]
+	public void Deserialize_Ssid_MapsCampusGatewayAndWlanIdentifier()
+	{
+		var ssid = Deserialize<Ssid>("""
+			{ "number": 0, "name": "Corp", "enabled": true, "campusGateway": { "cluster": { "id": "1" } }, "wlanIdentifier": 3 }
+			""");
+
+		_ = ssid.CampusGateway!.Cluster!.Id.Should().Be("1");
+		_ = ssid.WlanIdentifier.Should().Be(3);
+	}
+
+	// POST /networks/{networkId}/wireless/rfProfiles - "dot11be", previously mapped as "be".
+	[Fact]
+	public void Deserialize_WirelessRfProfile_MapsDot11be()
+	{
+		var profile = Deserialize<WirelessRfProfile>("""
+			{ "id": "1", "networkId": "N_1", "name": "Default", "dot11be": { "enabled": true, "mode": "per SSID group", "ssids": { "groups": { "1": { "enabled": true }, "2": { "enabled": false } } } } }
+			""");
+
+		_ = profile.Dot11be!.Enabled.Should().BeTrue();
+		_ = profile.Dot11be.Ssids!.Groups["2"].Enabled.Should().BeFalse();
+	}
+
+	// GET /networks/{networkId}/wireless/electronicShelfLabel
+	[Fact]
+	public void Deserialize_ElectronicShelfLabelSettingsNetwork_MapsSepioo()
+	{
+		var settings = Deserialize<ElectronicShelfLabelSettingsNetwork>("""
+			{ "enabled": true, "hostname": "esl.example.invalid", "mode": "high frequency", "sepioo": { "hostname": "sepioo.example.invalid" } }
+			""");
+
+		_ = settings.Sepioo!.Hostname.Should().Be("sepioo.example.invalid");
+	}
+
+	// GET /networks/{networkId}/wireless/airMarshal
+	[Fact]
+	public void Deserialize_AirMarshal_MapsEncryptionManufacturersAndTypes()
+	{
+		var entry = Deserialize<AirMarshal>("""
+			{ "ssid": "Rogue", "bssids": [], "channels": [ 6 ], "firstSeen": 1700000000, "lastSeen": 1700000600, "wiredMacs": [], "wiredVlans": [], "wiredLastSeen": 0, "encryption": "WPA", "manufacturers": [ "Example Inc" ], "types": [ "rogue" ] }
+			""");
+
+		_ = entry.Encryption.Should().Be("WPA");
+		_ = entry.Manufacturers.Should().ContainSingle();
+		_ = entry.Types.Should().ContainSingle().Which.Should().Be("rogue");
+	}
+
+	// wifi0[] from GET /networks/{networkId}/networkHealth/channelUtilization - the API's current names.
+	[Fact]
+	public void Deserialize_Wifi_MapsCurrentChannelUtilizationNames()
+	{
+		var wifi = Deserialize<Wifi>("""
+			{ "startTime": "2026-09-09T10:00:00Z", "endTime": "2026-09-09T10:10:00Z", "utilizationTotal": 40.5, "utilization80211": 30.25, "utilizationNon80211": 10.25 }
+			""");
+
+		_ = wifi.UtilizationTotalPercent.Should().Be(40.5);
+		_ = wifi.Utilization80211.Should().Be(30.25);
+		_ = wifi.EndTimeUtc.Should().Be(new DateTime(2026, 9, 9, 10, 10, 0, DateTimeKind.Utc));
+	}
+
+	// GET /organizations/{organizationId}/wirelessController/devices/interfaces/l2/usage/history/byInterval
+	// - "meta" was mapped as "name".
+	[Fact]
+	public void Deserialize_L2UsageHistoryByIntervalResponse_MapsMeta()
+	{
+		var response = Deserialize<OrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalGetResponse>("""
+			{ "items": [], "meta": { "counts": { "items": { "total": 0, "remaining": 0 } } } }
+			""");
+
+		_ = response.Meta.Should().NotBeNull();
+		_ = response.Items.Should().BeEmpty();
+	}
+
+	// Scalars added across the area.
+	[Fact]
+	public void Deserialize_WirelessScalars_Bind()
+	{
+		_ = Deserialize<Gre>("""{ "key": 5, "clientIsolation": true }""").ClientIsolation.Should().BeTrue();
+		_ = Deserialize<NaiRealm>("""{ "format": "0", "realm": "example.invalid", "name": "Example", "methods": [] }""").Name.Should().Be("Example");
+		_ = Deserialize<FailedConnection>("""{ "ssidNumber": 1, "vlan": 10, "clientMac": "00:11:22:33:44:55", "serial": "Q2XX-ABCD-1234", "failureStep": "auth", "type": "802.1X auth fail", "ts": "2026-09-09T10:00:00Z", "radio": 1 }""").Radio.Should().Be(1);
+		_ = Deserialize<ConnectivityEvents>("""{ "occurredAt": "2026-09-09T10:00:00Z", "ssidNumber": 2 }""").SsidNumber.Should().Be(2);
+		_ = Deserialize<SsidsStatusesByDeviceItemBasicServiceSetRadio>("""{ "band": "5", "channel": 36, "channelWidth": "80", "power": 20, "isBroadcasting": true, "index": "1" }""").Index.Should().Be("1");
+	}
+}

--- a/Meraki.Api/Data/AirMarshal.cs
+++ b/Meraki.Api/Data/AirMarshal.cs
@@ -53,4 +53,25 @@ public class AirMarshal
 	/// </summary>
 	[DataMember(Name = "wiredLastSeen")]
 	public int WiredLastSeen { get; set; }
+
+	/// <summary>
+	/// High-level encryption mode observed for the SSID ('WEP', 'WPA' or 'open'); null when it cannot be inferred
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "encryption")]
+	public string? Encryption { get; set; }
+
+	/// <summary>
+	/// Vendor names resolved from the OUI of each broadcasting BSSID (not the OUI hex prefix itself)
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "manufacturers")]
+	public List<string>? Manufacturers { get; set; }
+
+	/// <summary>
+	/// Threat classifications applied to this SSID, for example 'rogue', 'spoof', 'other', 'neighbor'
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "types")]
+	public List<string>? Types { get; set; }
 }

--- a/Meraki.Api/Data/ConnectivityEvents.cs
+++ b/Meraki.Api/Data/ConnectivityEvents.cs
@@ -77,4 +77,11 @@ public class ConnectivityEvents
 	/// </summary>
 	[DataMember(Name = "eventData")]
 	public EventData EventData { get; set; } = new();
+
+	/// <summary>
+	/// Number of the SSID the event occurred in
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "ssidNumber")]
+	public int? SsidNumber { get; set; }
 }

--- a/Meraki.Api/Data/DevicesWirelessZigbeeEnrollmentsDetailed.cs
+++ b/Meraki.Api/Data/DevicesWirelessZigbeeEnrollmentsDetailed.cs
@@ -15,11 +15,11 @@ public class DevicesWirelessZigbeeEnrollmentsDetailed
 	public string? EnrollmentId { get; set; }
 
 	/// <summary>
-	/// Enrollment started at
+	/// Enrollment status
 	/// </summary>
 	[DataMember(Name = "enrollmentStatus")]
 	[ApiAccess(ApiAccess.Read)]
-	public string? EnrollmentStartedAt { get; set; }
+	public string? EnrollmentStatus { get; set; }
 
 	/// <summary>
 	/// Status of the enrollment request
@@ -48,4 +48,11 @@ public class DevicesWirelessZigbeeEnrollmentsDetailed
 	[DataMember(Name = "doorLocks")]
 	[ApiAccess(ApiAccess.Read)]
 	public List<DevicesWirelessZigbeeDoorLocks>? DoorLocks { get; set; }
+
+	/// <summary>
+	/// Enrollment started at
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "enrollmentStartedAt")]
+	public DateTime? EnrollmentStartedAt { get; set; }
 }

--- a/Meraki.Api/Data/ElectronicShelfLabelSettingsNetwork.cs
+++ b/Meraki.Api/Data/ElectronicShelfLabelSettingsNetwork.cs
@@ -25,4 +25,11 @@ public class ElectronicShelfLabelSettingsNetwork
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "mode")]
 	public ElectronicShelfLabelSettingsNetworkMode? Mode { get; internal set; }
+
+	/// <summary>
+	/// sepioo IIoT settings
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "sepioo")]
+	public ElectronicShelfLabelSettingsNetworkSepioo? Sepioo { get; set; }
 }

--- a/Meraki.Api/Data/ElectronicShelfLabelSettingsNetworkSepioo.cs
+++ b/Meraki.Api/Data/ElectronicShelfLabelSettingsNetworkSepioo.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// sepioo IIoT settings for electronic shelf labels
+/// </summary>
+[DataContract]
+public class ElectronicShelfLabelSettingsNetworkSepioo
+{
+	/// <summary>
+	/// The sepioo hostname
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "hostname")]
+	public string? Hostname { get; set; }
+}

--- a/Meraki.Api/Data/FailedConnection.cs
+++ b/Meraki.Api/Data/FailedConnection.cs
@@ -47,4 +47,11 @@ public class FailedConnection
 	/// </summary>
 	[DataMember(Name = "ts")]
 	public DateTime Ts { get; set; }
+
+	/// <summary>
+	/// Radio number
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "radio")]
+	public int? Radio { get; set; }
 }

--- a/Meraki.Api/Data/Gre.cs
+++ b/Meraki.Api/Data/Gre.cs
@@ -18,4 +18,11 @@ public class Gre
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "concentrator")]
 	public GreConcentrator? Concentrator { get; set; }
+
+	/// <summary>
+	/// Whether or not client isolation is enabled.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "clientIsolation")]
+	public bool? ClientIsolation { get; set; }
 }

--- a/Meraki.Api/Data/NaiRealm.cs
+++ b/Meraki.Api/Data/NaiRealm.cs
@@ -25,4 +25,11 @@ public class NaiRealm
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "methods")]
 	public List<EapMethod> Methods { get; set; } = [];
+
+	/// <summary>
+	/// The name of the realm
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "name")]
+	public string? Name { get; set; }
 }

--- a/Meraki.Api/Data/OrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalGetResponse.cs
+++ b/Meraki.Api/Data/OrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalGetResponse.cs
@@ -10,7 +10,7 @@ public class OrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInte
 	/// Metadata relevant to the paginated dataset
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "name")]
+	[DataMember(Name = "meta")]
 	public OrganizationWirelessControllerDevicesInterfacesL2GetResponseMetadata Meta { get; set; } = new();
 
 	/// <summary>

--- a/Meraki.Api/Data/Ssid.cs
+++ b/Meraki.Api/Data/Ssid.cs
@@ -41,4 +41,18 @@ public class Ssid : SsidUpdateRequest
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "security")]
 	public SsidSecurity? Security { get; set; }
+
+	/// <summary>
+	/// Campus gateway settings. Only present when ipAssignmentMode is 'Campus Gateway'.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "campusGateway")]
+	public SsidCampusGateway? CampusGateway { get; set; }
+
+	/// <summary>
+	/// WLAN identifier for the SSID. Only present for Meraki admin users.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "wlanIdentifier")]
+	public int? WlanIdentifier { get; set; }
 }

--- a/Meraki.Api/Data/SsidCampusGateway.cs
+++ b/Meraki.Api/Data/SsidCampusGateway.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// Campus gateway settings for an SSID. Only present when ipAssignmentMode is 'Campus Gateway'.
+/// </summary>
+[DataContract]
+public class SsidCampusGateway
+{
+	/// <summary>
+	/// The campus gateway cluster the SSID is assigned to
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "cluster")]
+	public SsidCampusGatewayCluster? Cluster { get; set; }
+}

--- a/Meraki.Api/Data/SsidCampusGatewayCluster.cs
+++ b/Meraki.Api/Data/SsidCampusGatewayCluster.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// The campus gateway cluster an SSID is assigned to
+/// </summary>
+[DataContract]
+public class SsidCampusGatewayCluster
+{
+	/// <summary>
+	/// ID of the campus gateway cluster
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "id")]
+	public string? Id { get; set; }
+}

--- a/Meraki.Api/Data/SsidsStatusesByDeviceItemBasicServiceSetRadio.cs
+++ b/Meraki.Api/Data/SsidsStatusesByDeviceItemBasicServiceSetRadio.cs
@@ -36,4 +36,11 @@ public class SsidsStatusesByDeviceItemBasicServiceSetRadio
 	/// </summary>
 	[DataMember(Name = "isBroadcasting")]
 	public bool IsBroadcasting { get; set; }
+
+	/// <summary>
+	/// The radio index.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "index")]
+	public string? Index { get; set; }
 }

--- a/Meraki.Api/Data/Wifi.cs
+++ b/Meraki.Api/Data/Wifi.cs
@@ -36,4 +36,39 @@ public class Wifi
 	/// </summary>
 	[DataMember(Name = "non_wifi")]
 	public double UtilizationNonWifi { get; set; }
+
+	/// <summary>
+	/// The start time of the channel utilization interval, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "startTime")]
+	public DateTime? StartTimeUtc { get; set; }
+
+	/// <summary>
+	/// The end time of the channel utilization interval, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "endTime")]
+	public DateTime? EndTimeUtc { get; set; }
+
+	/// <summary>
+	/// Percentage of total channel utilization for the given radio, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "utilizationTotal")]
+	public double? UtilizationTotalPercent { get; set; }
+
+	/// <summary>
+	/// Percentage of wifi channel utilization for the given radio, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "utilization80211")]
+	public double? Utilization80211 { get; set; }
+
+	/// <summary>
+	/// Percentage of non-wifi channel utilization for the given radio, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "utilizationNon80211")]
+	public double? UtilizationNon80211 { get; set; }
 }

--- a/Meraki.Api/Data/WirelessRfProfileBe.cs
+++ b/Meraki.Api/Data/WirelessRfProfileBe.cs
@@ -12,4 +12,18 @@ public class WirelessRfProfileBe
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "enabled")]
 	public bool? Enabled { get; set; }
+
+	/// <summary>
+	/// 802.11be is enabled for 'all SSIDs' or 'per SSID group'
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "mode")]
+	public string? Mode { get; set; }
+
+	/// <summary>
+	/// 802.11be settings for SSIDs
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "ssids")]
+	public WirelessRfProfileBeSsids? Ssids { get; set; }
 }

--- a/Meraki.Api/Data/WirelessRfProfileBeSsidGroup.cs
+++ b/Meraki.Api/Data/WirelessRfProfileBeSsidGroup.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// 802.11be settings for one SSID group
+/// </summary>
+[DataContract]
+public class WirelessRfProfileBeSsidGroup
+{
+	/// <summary>
+	/// Whether 802.11be is enabled for the SSID group
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
+}

--- a/Meraki.Api/Data/WirelessRfProfileBeSsids.cs
+++ b/Meraki.Api/Data/WirelessRfProfileBeSsids.cs
@@ -1,0 +1,15 @@
+namespace Meraki.Api.Data;
+
+/// <summary>
+/// 802.11be settings for SSIDs
+/// </summary>
+[DataContract]
+public class WirelessRfProfileBeSsids
+{
+	/// <summary>
+	/// 802.11be settings for SSID groups, keyed by group number: '1' is SSIDs 0-3, '2' is 4-7, '3' is 8-11, '4' is 12-14
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "groups")]
+	public Dictionary<string, WirelessRfProfileBeSsidGroup> Groups { get; set; } = [];
+}

--- a/Meraki.Api/Data/WirelessRfProfileCreateUpdateRequest.cs
+++ b/Meraki.Api/Data/WirelessRfProfileCreateUpdateRequest.cs
@@ -105,9 +105,9 @@ public class WirelessRfProfileCreateUpdateRequest
 	public WirelessRfProfileFlexRadios? FlexRadios { get; set; }
 
 	/// <summary>
-	/// Gets the be
+	/// 802.11be settings
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadWrite)]
-	[DataMember(Name = "be")]
-	public WirelessRfProfileBe? Be { get; set; }
+	[DataMember(Name = "dot11be")]
+	public WirelessRfProfileBe? Dot11be { get; set; }
 }


### PR DESCRIPTION
## Stacked on #419 → #418 → #417 → #416 → #415

Base is `feat/map-appliance-members`. Merge the chain in order with merge commits, then retarget this to `main`. Changelog label `1.74.15` assumes that.

## What

Fourth per-area batch from `gap-report-v1.74.0.md`: **19 Wireless members** the spec documents that the models lacked, across 12 classes.

| Member | Notes |
|---|---|
| `Ssid.CampusGateway`, `.WlanIdentifier` | new `SsidCampusGateway` → `SsidCampusGatewayCluster {id}` |
| `ElectronicShelfLabelSettingsNetwork.Sepioo` | new `…Sepioo {hostname}` |
| `AirMarshal.Encryption`, `.Manufacturers`, `.Types` | `string?` (spec enum WEP/WPA/open, kept as string), `List<string>?` ×2 |
| `Gre.ClientIsolation`, `NaiRealm.Name`, `FailedConnection.Radio`, `ConnectivityEvents.SsidNumber`, `SsidsStatusesByDeviceItemBasicServiceSetRadio.Index`, `DevicesWirelessZigbeeEnrollmentsDetailed.EnrollmentStartedAt` | scalars |
| `Wifi` (channel utilization) | the API's current `startTime`/`endTime`/`utilizationTotal`/`utilization80211`/`utilizationNon80211` **alongside** the legacy `start_ts`/`end_ts`/`utilization`/`wifi`/`non_wifi` — I don't know which set the live API sends, so nothing was removed |

## Three corrections (never bound before)

1. **`…L2UsageHistoryByIntervalGetResponse.Meta`** was `[DataMember(Name = "name")]`. Its two sibling L2 responses say `"meta"`; this one now does too.
2. **`WirelessRfProfileCreateUpdateRequest.Be`** was mapped to `be`; the API sends `dot11be`. Renamed `Dot11be`, and `WirelessRfProfileBe` gains the spec's `Mode` and `Ssids` (per-SSID-group `{enabled}`, keyed `"1"`–`"4"`, as a `Dictionary`). Breaking rename, but the old property never bound.
3. **`DevicesWirelessZigbeeEnrollmentsDetailed.EnrollmentStartedAt`** was a `string?` bound to `enrollmentStatus` — found because adding the real `enrollmentStartedAt` collided with it. Renamed `EnrollmentStatus`; the new `EnrollmentStartedAt` is a `DateTime?`.

## Verification

```
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s), 6 pre-existing CS0618 warnings
Meraki.Api.Test (Data namespace)        Total: 48, Errors: 0, Failed: 0   (7 new in WirelessMemberTests)
Meraki.Api.Test (Workflows)             Total: 12, Errors: 0, Failed: 0
```

All 13 edited files kept their BOM state and line endings.
