### PR TITLE
feat: map the Switch, Camera, Sensor and Cellular Gateway members from the 1.74.0 gap report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 ﻿# Changelog
 
+## 1.74.17
+
+- **Twenty-two Switch, Camera, Sensor and Cellular Gateway response members the v1.74.0 spec
+  documents are now mapped**, the fifth per-area batch from the gap report:
+  `AlternateManagementInterface.UseOobMgmt`, `ConfigOverrides.VoiceVlan`, `SwitchPort.StpPortFastTrunk`
+  and `ConfigTemplateSwitchProfilePort.StpPortFastTrunk`, `StackDevice.ProductType`,
+  `SwitchPortsUsageHistoryByDeviceByIntervalItem.Serial`; `PermissionLevel` and `PermissionScope` on
+  `CameraRoleAppliedOnDevice`, `CameraRoleAppliedOnNetwork` and `CameraRoleAppliedOrgWide` (plus `Tag`
+  on the last); `No2`, `O3` and `Pm10` on `SensorReadingHistoric` and `SensorReadingLatestReading`
+  (reusing `SensorMetricConcentration`); `NetworkCellularGatewayEsimsInventoryItemDevice.Status`.
+
+- **Six members that could never bind are corrected** (breaking in the type-system sense only):
+  - `ConfigTemplateSwitchProfilePortDot3az.Dot3az` was mapped to `dot3az`; the API sends `enabled`.
+    Now `Enabled`, matching `SwitchPortDot3az`.
+  - `NetworksSwitchDhcpV4ServersSeenLastPacketSourceIpv4.Ipv4` was mapped to `ipv4`; the API sends
+    `address`. Now `Address`.
+  - `EsimsServiceProvidersItemLogo.Logo` was mapped to `logo`; the API sends `url`. Now `Url`.
+  - `EsimsServiceProvidersAccounts.Items` was a list of `EsimsServiceProvidersAccountsItem`, which is
+    itself an `{items, meta}` wrapper, so no account ever bound. It is now
+    `List<NetworkCellularGatewayEsimsServiceProviderAccount>`; the old item type is `[Obsolete]`.
+  - `CameraLive.Zones` was a `Zones` class with a single fixed `"0"` member; the API keys zones by
+    zone ID. It is now `Dictionary<string, ZoneData>`, and `Zones` is `[Obsolete]`.
+  - `ZoneData.Person` had no `[DataMember]` inside a `[DataContract]` class, so Newtonsoft ignored it.
+
+  - `SensorMetrics` lacked `No2`, `O3` and `Pm10`, so a reading whose `metric` was one of them threw
+    on deserialization rather than binding; the three values are added.
+  - `IOrganizationSwitches` had a second `GetOrganizationSwitchPortsTopologyDiscoveryByDeviceAsync`
+    overload, taking the usage-history filter parameters, whose `[Get]` path was the **usage-history**
+    endpoint and whose return type was the topology model, so it could never have returned anything
+    usable. It is removed; the single-parameter overload with the correct path remains.
+
+  Regression tests are in `Meraki.Api.Test.Data.SwitchCameraSensorCellularMemberTests`.
+
 ## 1.74.15
 
 - **Nineteen Wireless response members the v1.74.0 spec documents are now mapped**, the fourth

--- a/Meraki.Api.Test/Data/SwitchCameraSensorCellularMemberTests.cs
+++ b/Meraki.Api.Test/Data/SwitchCameraSensorCellularMemberTests.cs
@@ -1,0 +1,110 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for Switch, Camera, Sensor and Cellular Gateway response members the v1.74.0
+/// OpenAPI spec documents that the models lacked. Each payload has the shape the spec documents, and
+/// is deserialized with the settings <see cref="JsonMissingMemberHandling.ThrowOnError"/> uses so an
+/// unmapped field fails the test rather than being dropped.
+/// </summary>
+public class SwitchCameraSensorCellularMemberTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// GET /devices/{serial}/switch/ports/{portId} and the config template equivalent
+	[Fact]
+	public void Deserialize_SwitchPorts_MapStpPortFastTrunkAndDot3azEnabled()
+	{
+		_ = Deserialize<SwitchPort>("""{ "portId": "1", "name": "Uplink", "stpPortFastTrunk": true }""").StpPortFastTrunk.Should().BeTrue();
+
+		var templatePort = Deserialize<ConfigTemplateSwitchProfilePort>("""{ "portId": "1", "name": "Uplink", "stpPortFastTrunk": false, "dot3az": { "enabled": true } }""");
+
+		_ = templatePort.StpPortFastTrunk.Should().BeFalse();
+		_ = templatePort.Dot3az!.Enabled.Should().BeTrue();
+	}
+
+	// GET /networks/{networkId}/switch/dhcp/v4/servers/seen - source.ipv4 is {address}, not a string.
+	[Fact]
+	public void Deserialize_DhcpV4ServersSeenSourceIpv4_MapsAddress()
+	{
+		var ipv4 = Deserialize<NetworksSwitchDhcpV4ServersSeenLastPacketSourceIpv4>("""{ "address": "10.0.0.1" }""");
+
+		_ = ipv4.Address.Should().Be("10.0.0.1");
+	}
+
+	// Switch scalars.
+	[Fact]
+	public void Deserialize_SwitchScalars_Bind()
+	{
+		_ = Deserialize<AlternateManagementInterface>("""{ "enabled": true, "vlanId": 100, "protocols": [], "switches": [], "useOobMgmt": true }""").UseOobMgmt.Should().BeTrue();
+		_ = Deserialize<ConfigOverrides>("""{ "type": "access", "allowedVlans": "all", "vlan": 10, "voiceVlan": 20 }""").VoiceVlan.Should().Be(20);
+		_ = Deserialize<StackDevice>("""{ "serial": "Q2XX-ABCD-1234", "name": "sw1", "productType": "switch" }""").ProductType.Should().Be("switch");
+	}
+
+	// appliedOrgWide[] from POST /organizations/{organizationId}/camera/roles
+	[Fact]
+	public void Deserialize_CameraRoleAppliedOrgWide_MapsPermissionFields()
+	{
+		var applied = Deserialize<CameraRoleAppliedOrgWide>("""{ "tag": "cameras", "permissionScopeId": "1", "permissionScope": "Camera viewer", "permissionLevel": "view" }""");
+
+		_ = applied.PermissionLevel.Should().Be("view");
+		_ = applied.PermissionScope.Should().Be("Camera viewer");
+		_ = applied.Tag.Should().Be("cameras");
+	}
+
+	// GET /devices/{serial}/camera/analytics/live - zones are keyed by zone ID, and ZoneData.Person
+	// previously had no [DataMember] so was ignored inside a [DataContract] class.
+	[Fact]
+	public void Deserialize_CameraLive_MapsZonesByIdWithPersonCount()
+	{
+		var live = Deserialize<CameraLive>("""{ "ts": "2026-09-09T10:00:00Z", "zones": { "0": { "person": 2 }, "1234": { "person": 0 } } }""");
+
+		_ = live.Zones.Should().HaveCount(2);
+		_ = live.Zones["0"].Person.Should().Be(2);
+	}
+
+	// GET /organizations/{organizationId}/sensor/readings/latest - the newer air-quality metrics.
+	[Fact]
+	public void Deserialize_SensorReadingLatestReading_MapsNo2O3Pm10()
+	{
+		var reading = Deserialize<SensorReadingLatestReading>("""{ "ts": "2026-09-09T10:00:00Z", "metric": "pm10", "no2": { "concentration": 12 }, "o3": { "concentration": 30 }, "pm10": { "concentration": 8 } }""");
+
+		_ = reading.Pm10!.Concentration.Should().Be(8);
+		_ = reading.No2!.Concentration.Should().Be(12);
+	}
+
+	// GET /organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts - Items was a
+	// list of a wrapper type, so no account ever bound.
+	[Fact]
+	public void Deserialize_EsimsServiceProvidersAccounts_MapsAccounts()
+	{
+		var accounts = Deserialize<EsimsServiceProvidersAccounts>("""
+			{ "items": [ { "accountId": "1", "lastUpdatedAt": "2026-09-09T10:00:00Z", "title": "Example", "username": "user", "serviceProvider": { "name": "Example Mobile", "logo": { "url": "https://example.invalid/logo.png" } } } ], "meta": { "counts": { "items": { "total": 1, "remaining": 0 } } } }
+			""");
+
+		_ = accounts.Items.Should().ContainSingle().Which.AccountId.Should().Be("1");
+		_ = accounts.Meta.Counts!.Items.Total.Should().Be(1);
+	}
+
+	// GET /organizations/{organizationId}/cellularGateway/esims/serviceProviders - logo is {url}.
+	[Fact]
+	public void Deserialize_EsimsServiceProvidersItemLogo_MapsUrl()
+	{
+		_ = Deserialize<EsimsServiceProvidersItemLogo>("""{ "url": "https://example.invalid/logo.png" }""").Url.Should().Be("https://example.invalid/logo.png");
+		_ = Deserialize<NetworkCellularGatewayEsimsInventoryItemDevice>("""{ "model": "MG41", "name": "mg1", "serial": "Q2XX-ABCD-1234", "url": "https://example.invalid", "status": "online" }""").Status.Should().Be("online");
+	}
+}

--- a/Meraki.Api/Data/AlternateManagementInterface.cs
+++ b/Meraki.Api/Data/AlternateManagementInterface.cs
@@ -33,4 +33,11 @@ public class AlternateManagementInterface
 	[ApiAccess(ApiAccess.ReadUpdate)]
 	[DataMember(Name = "switches")]
 	public List<AlternateManagementSwitch> Switches { get; set; } = [];
+
+	/// <summary>
+	/// Boolean value to use out-of-band management interface when configured
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "useOobMgmt")]
+	public bool? UseOobMgmt { get; set; }
 }

--- a/Meraki.Api/Data/CameraLive.cs
+++ b/Meraki.Api/Data/CameraLive.cs
@@ -13,8 +13,9 @@ public class CameraLive
 	public string Ts { get; set; } = string.Empty;
 
 	/// <summary>
-	/// Zones
+	/// The zones state, keyed by zone ID
 	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "zones")]
-	public Zones Zones { get; set; } = new();
+	public Dictionary<string, ZoneData> Zones { get; set; } = [];
 }

--- a/Meraki.Api/Data/CameraRoleAppliedOnDevice.cs
+++ b/Meraki.Api/Data/CameraRoleAppliedOnDevice.cs
@@ -40,4 +40,18 @@ public class CameraRoleAppliedOnDevice
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "tag")]
 	public string? Tag { get; set; }
+
+	/// <summary>
+	/// Permission level
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "permissionLevel")]
+	public string? PermissionLevel { get; set; }
+
+	/// <summary>
+	/// Permission scope name
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "permissionScope")]
+	public string? PermissionScope { get; set; }
 }

--- a/Meraki.Api/Data/CameraRoleAppliedOnNetwork.cs
+++ b/Meraki.Api/Data/CameraRoleAppliedOnNetwork.cs
@@ -26,4 +26,18 @@ public class CameraRoleAppliedOnNetwork
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "tag")]
 	public string? Tag { get; set; }
+
+	/// <summary>
+	/// Permission level
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "permissionLevel")]
+	public string? PermissionLevel { get; set; }
+
+	/// <summary>
+	/// Permission scope name
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "permissionScope")]
+	public string? PermissionScope { get; set; }
 }

--- a/Meraki.Api/Data/CameraRoleAppliedOrgWide.cs
+++ b/Meraki.Api/Data/CameraRoleAppliedOrgWide.cs
@@ -12,4 +12,25 @@ public class CameraRoleAppliedOrgWide
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "permissionScopeId")]
 	public string? PermissionScopeId { get; set; }
+
+	/// <summary>
+	/// Permission level
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "permissionLevel")]
+	public string? PermissionLevel { get; set; }
+
+	/// <summary>
+	/// Permission scope name
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "permissionScope")]
+	public string? PermissionScope { get; set; }
+
+	/// <summary>
+	/// Organization tag
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadWrite)]
+	[DataMember(Name = "tag")]
+	public string? Tag { get; set; }
 }

--- a/Meraki.Api/Data/ConfigOverrides.cs
+++ b/Meraki.Api/Data/ConfigOverrides.cs
@@ -26,4 +26,11 @@ public class ConfigOverrides
 	[ApiAccess(ApiAccess.ReadWrite)]
 	[DataMember(Name = "vlan")]
 	public int? Vlan { get; set; }
+
+	/// <summary>
+	/// The voice VLAN of the port. Only applicable to access ports.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "voiceVlan")]
+	public int? VoiceVlan { get; set; }
 }

--- a/Meraki.Api/Data/ConfigTemplateSwitchProfilePort.cs
+++ b/Meraki.Api/Data/ConfigTemplateSwitchProfilePort.cs
@@ -247,4 +247,11 @@ public class ConfigTemplateSwitchProfilePort : NamedItem
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "stackwiseVirtual")]
 	public SwitchPortStackwiseVirtual? StackwiseVirtual { get; set; }
+
+	/// <summary>
+	/// The state of STP PortFast Trunk on the switch template port.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "stpPortFastTrunk")]
+	public bool? StpPortFastTrunk { get; set; }
 }

--- a/Meraki.Api/Data/ConfigTemplateSwitchProfilePortDot3az.cs
+++ b/Meraki.Api/Data/ConfigTemplateSwitchProfilePortDot3az.cs
@@ -10,6 +10,6 @@ public class ConfigTemplateSwitchProfilePortDot3az
 	/// The Energy Efficient Ethernet status of the switch template port.
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadUpdate)]
-	[DataMember(Name = "dot3az")]
-	public bool? Dot3az { get; set; }
+	[DataMember(Name = "enabled")]
+	public bool? Enabled { get; set; }
 }

--- a/Meraki.Api/Data/EsimsServiceProvidersAccounts.cs
+++ b/Meraki.Api/Data/EsimsServiceProvidersAccounts.cs
@@ -5,11 +5,11 @@ namespace Meraki.Api.Data;
 /// </summary>
 [DataContract]
 public class EsimsServiceProvidersAccounts
-	: ItemsResponseWithMeta<EsimsServiceProvidersAccountsItem>
+	: ItemsResponseWithMeta<NetworkCellularGatewayEsimsServiceProviderAccount>
 {
 	/// <summary>
 	/// List of Cellular Service Provider Accounts
 	/// </summary>
 	[ApiAccess(ApiAccess.ReadWrite)]
-	public override List<EsimsServiceProvidersAccountsItem> Items { get; set; } = [];
+	public override List<NetworkCellularGatewayEsimsServiceProviderAccount> Items { get; set; } = [];
 }

--- a/Meraki.Api/Data/EsimsServiceProvidersAccountsItem.cs
+++ b/Meraki.Api/Data/EsimsServiceProvidersAccountsItem.cs
@@ -3,6 +3,7 @@ namespace Meraki.Api.Data;
 /// <summary>
 /// Esims Service Providers Accounts
 /// </summary>
+[Obsolete("Was the item type of EsimsServiceProvidersAccounts but is itself an {items, meta} wrapper, so no account ever bound. EsimsServiceProvidersAccounts.Items is now List<NetworkCellularGatewayEsimsServiceProviderAccount>. This type will be removed in a later release.")]
 [DataContract]
 public class EsimsServiceProvidersAccountsItem
 	: ItemsResponseWithMeta<NetworkCellularGatewayEsimsServiceProviderAccount>

--- a/Meraki.Api/Data/EsimsServiceProvidersItemLogo.cs
+++ b/Meraki.Api/Data/EsimsServiceProvidersItemLogo.cs
@@ -10,6 +10,6 @@ public class EsimsServiceProvidersItemLogo
 	/// URL of service provider's logo.
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "logo")]
-	public string? Logo { get; set; }
+	[DataMember(Name = "url")]
+	public string? Url { get; set; }
 }

--- a/Meraki.Api/Data/NetworkCellularGatewayEsimsInventoryItemDevice.cs
+++ b/Meraki.Api/Data/NetworkCellularGatewayEsimsInventoryItemDevice.cs
@@ -34,4 +34,11 @@ public class NetworkCellularGatewayEsimsInventoryItemDevice
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "url")]
 	public string Url { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Device status
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "status")]
+	public string? Status { get; set; }
 }

--- a/Meraki.Api/Data/NetworksSwitchDhcpV4ServersSeenLastPacketSourceIpv4.cs
+++ b/Meraki.Api/Data/NetworksSwitchDhcpV4ServersSeenLastPacketSourceIpv4.cs
@@ -10,6 +10,6 @@ public class NetworksSwitchDhcpV4ServersSeenLastPacketSourceIpv4
 	/// Source ipv4 address of the packet.
 	/// </summary>
 	[ApiAccess(ApiAccess.Read)]
-	[DataMember(Name = "ipv4")]
-	public string Ipv4 { get; set; } = string.Empty;
+	[DataMember(Name = "address")]
+	public string Address { get; set; } = string.Empty;
 }

--- a/Meraki.Api/Data/SensorMetrics.cs
+++ b/Meraki.Api/Data/SensorMetrics.cs
@@ -132,4 +132,22 @@ public enum SensorMetrics
 	/// </summary>
 	[EnumMember(Value = "rawTemperature")]
 	RawTemperature,
+
+	/// <summary>
+	/// Nitrogen dioxide concentration
+	/// </summary>
+	[EnumMember(Value = "no2")]
+	No2,
+
+	/// <summary>
+	/// Ozone concentration
+	/// </summary>
+	[EnumMember(Value = "o3")]
+	O3,
+
+	/// <summary>
+	/// PM10 particulate concentration
+	/// </summary>
+	[EnumMember(Value = "pm10")]
+	Pm10
 }

--- a/Meraki.Api/Data/SensorReadingHistoric.cs
+++ b/Meraki.Api/Data/SensorReadingHistoric.cs
@@ -161,4 +161,25 @@ public class SensorReadingHistoric
 	/// </summary>
 	[DataMember(Name = "water")]
 	public SensorMetricWater? Water { get; set; }
+
+	/// <summary>
+	/// Reading for the 'no2' metric. This will only be present if the 'metric' property equals 'no2'.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "no2")]
+	public SensorMetricConcentration? No2 { get; set; }
+
+	/// <summary>
+	/// Reading for the 'o3' metric. This will only be present if the 'metric' property equals 'o3'.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "o3")]
+	public SensorMetricConcentration? O3 { get; set; }
+
+	/// <summary>
+	/// Reading for the 'pm10' metric. This will only be present if the 'metric' property equals 'pm10'.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "pm10")]
+	public SensorMetricConcentration? Pm10 { get; set; }
 }

--- a/Meraki.Api/Data/SensorReadingLatestReading.cs
+++ b/Meraki.Api/Data/SensorReadingLatestReading.cs
@@ -144,4 +144,25 @@ public class SensorReadingLatestReading
 	/// </summary>
 	[DataMember(Name = "water")]
 	public SensorMetricWater? Water { get; set; }
+
+	/// <summary>
+	/// Reading for the 'no2' metric. This will only be present if the 'metric' property equals 'no2'.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "no2")]
+	public SensorMetricConcentration? No2 { get; set; }
+
+	/// <summary>
+	/// Reading for the 'o3' metric. This will only be present if the 'metric' property equals 'o3'.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "o3")]
+	public SensorMetricConcentration? O3 { get; set; }
+
+	/// <summary>
+	/// Reading for the 'pm10' metric. This will only be present if the 'metric' property equals 'pm10'.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "pm10")]
+	public SensorMetricConcentration? Pm10 { get; set; }
 }

--- a/Meraki.Api/Data/StackDevice.cs
+++ b/Meraki.Api/Data/StackDevice.cs
@@ -59,4 +59,11 @@ public class StackDevice
 	/// </summary>
 	[DataMember(Name = "uplinks")]
 	public List<StackDeviceUplinks> Uplinks { get; set; } = [];
+
+	/// <summary>
+	/// The product type of the device
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "productType")]
+	public string? ProductType { get; set; }
 }

--- a/Meraki.Api/Data/SwitchPort.cs
+++ b/Meraki.Api/Data/SwitchPort.cs
@@ -267,4 +267,11 @@ public class SwitchPort : NamedItem
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "stackwiseVirtual")]
 	public SwitchPortStackwiseVirtual? StackwiseVirtual { get; set; }
+
+	/// <summary>
+	/// The state of STP PortFast Trunk on the switch port.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadUpdate)]
+	[DataMember(Name = "stpPortFastTrunk")]
+	public bool? StpPortFastTrunk { get; set; }
 }

--- a/Meraki.Api/Data/SwitchPortsUsageHistoryByDeviceByIntervalItem.cs
+++ b/Meraki.Api/Data/SwitchPortsUsageHistoryByDeviceByIntervalItem.cs
@@ -41,4 +41,10 @@ public class SwitchPortsUsageHistoryByDeviceByIntervalItem
 	[DataMember(Name = "ports")]
 	public List<SwitchPortsUsageHistoryByDeviceByIntervalItemPort> Ports { get; set; } = [];
 
+	/// <summary>
+	/// The serial number of the switch.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "serial")]
+	public string? Serial { get; set; }
 }

--- a/Meraki.Api/Data/ZoneData.cs
+++ b/Meraki.Api/Data/ZoneData.cs
@@ -7,7 +7,9 @@
 public class ZoneData
 {
 	/// <summary>
-	/// Person
+	/// The number of people detected in the zone
 	/// </summary>
-	public int Person { get; set; }
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "person")]
+	public int? Person { get; set; }
 }

--- a/Meraki.Api/Data/Zones.cs
+++ b/Meraki.Api/Data/Zones.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Zones
 /// </summary>
+[Obsolete("Camera analytics zones are keyed by zone ID, not fixed to \"0\". CameraLive.Zones is now Dictionary<string, ZoneData>. This type will be removed in a later release.")]
 [DataContract]
 public class Zones
 {

--- a/Meraki.Api/Interfaces/General/Organizations/IOrganizationSwitches.cs
+++ b/Meraki.Api/Interfaces/General/Organizations/IOrganizationSwitches.cs
@@ -435,49 +435,6 @@ public interface IOrganizationSwitches
 		);
 
 	/// <summary>
-	/// List most recently seen LLDP/CDP discovery and topology information per switch port in an organization.
-	/// </summary>
-	/// <exception cref="ApiException">Thrown when fails to make API call</exception>
-	/// <param name="organizationId">The OrganizationID</param>
-	/// <param name="t0">The beginning of the timespan for the data. The maximum lookback period is 31 days from today.</param>
-	/// <param name="t1"></param>
-	/// <param name="timespan">The timespan for which the information will be fetched. If specifying timespan, do not specify parameter t0. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.</param>
-	/// <param name="interval"></param>
-	/// <param name="perPage">The number of entries per page returned. Acceptable range is 3 - 20. Default is 10.</param>
-	/// <param name="startingAfter">A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.</param>
-	/// <param name="endingBefore">A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.</param>
-	/// <param name="configurationUpdatedAfter">Optional parameter to filter results by switches where the configuration has been updated after the given timestamp</param>
-	/// <param name="mac">Optional parameter to filter switchports belonging to switches by MAC address. All returned switches will have a MAC address that contains the search term or is an exact match.</param>
-	/// <param name="macs">Optional parameter to filter items to switches that have one of the provided MAC addresses.</param>
-	/// <param name="name">Optional parameter to filter items to switches with names that contain the search term or are an exact match.</param>
-	/// <param name="networkIds">Optional parameter to filter items to switches in one of the provided networks.</param>
-	/// <param name="portProfileIds">Optional parameter to filter items to switches that contain switchports belonging to one of the specified port profiles.</param>
-	/// <param name="serial">Optional parameter to filter switchports belonging to switches by serial number. All returned switches will have a serial number that contains the search term or is an exact match.</param>
-	/// <param name="serials">Optional parameter to filter switchports belonging to switches with one or more serial numbers. All switchports returned belong to serial numbers of switches that are an exact match.</param>
-	/// <param name="cancellationToken"></param>
-	[ApiOperationId("getOrganizationSwitchPortsTopologyDiscoveryByDevice")]
-	[Get("/organizations/{organizationId}/switch/ports/usage/history/byDevice/byInterval")]
-	Task<SwitchPortsTopologyDiscoveryByDevice> GetOrganizationSwitchPortsTopologyDiscoveryByDeviceAsync(
-		string organizationId,
-		string? t0,
-		string? t1,
-		int? timespan,
-		int? interval,
-		int? perPage,
-		string? startingAfter,
-		string? endingBefore,
-		string? configurationUpdatedAfter,
-		string? mac,
-		[AliasAs("macs[]")] List<string>? macs,
-		string? name,
-		[AliasAs("networkIds[]")] List<string>? networkIds,
-		[AliasAs("portProfileIds[]")] List<string>? portProfileIds,
-		string? serial,
-		[AliasAs("serials[]")] List<string>? serials,
-		CancellationToken cancellationToken = default
-		);
-
-	/// <summary>
 	/// Return time-series digital optical monitoring (DOM) readings for ports on each DOM-enabled switch in an organization, in addition to thresholds for each relevant Small Form Factor Pluggable (SFP) module.
 	/// </summary>
 	/// <exception cref="ApiException">Thrown when fails to make API call</exception>


### PR DESCRIPTION
## Stacked on #420 → #419 → #418 → #417 → #416 → #415

Base is `feat/map-wireless-members`. Merge the chain in order with merge commits, then retarget this to `main`. Changelog label `1.74.17` assumes that.

## What

Fifth per-area batch from `gap-report-v1.74.0.md`: **22 members** across Switch, Camera, Sensor and Cellular Gateway (the four small areas, combined so the PR is still a sensible size).

| Area | Added |
|---|---|
| Switch | `AlternateManagementInterface.UseOobMgmt`, `ConfigOverrides.VoiceVlan`, `SwitchPort.StpPortFastTrunk`, `ConfigTemplateSwitchProfilePort.StpPortFastTrunk`, `StackDevice.ProductType`, `SwitchPortsUsageHistoryByDeviceByIntervalItem.Serial` |
| Camera | `PermissionLevel` + `PermissionScope` on all three `CameraRoleApplied*` types, `Tag` on `…OrgWide` |
| Sensor | `No2`, `O3`, `Pm10` on `SensorReadingHistoric` and `SensorReadingLatestReading` (reusing `SensorMetricConcentration`) |
| Cellular Gateway | `NetworkCellularGatewayEsimsInventoryItemDevice.Status` |

## Eight corrections — none of these ever bound

| Was | Now |
|---|---|
| `ConfigTemplateSwitchProfilePortDot3az.Dot3az` ← `dot3az` | `Enabled` ← `enabled` (matches `SwitchPortDot3az`) |
| `NetworksSwitchDhcpV4ServersSeenLastPacketSourceIpv4.Ipv4` ← `ipv4` | `Address` ← `address` |
| `EsimsServiceProvidersItemLogo.Logo` ← `logo` | `Url` ← `url` |
| `EsimsServiceProvidersAccounts.Items : List<EsimsServiceProvidersAccountsItem>` — the item type is **itself** an `{items, meta}` wrapper | `List<NetworkCellularGatewayEsimsServiceProviderAccount>`; old item type `[Obsolete]` |
| `CameraLive.Zones : Zones` with one fixed `"0"` member | `Dictionary<string, ZoneData>` keyed by zone ID; `Zones` `[Obsolete]` |
| `ZoneData.Person` with no `[DataMember]` inside a `[DataContract]` class (Newtonsoft ignores it) | `[DataMember(Name = "person")]`, `int?` |
| `SensorMetrics` without `no2`/`o3`/`pm10` — a reading with one of those **threw** (`Requested value 'pm10' was not found`) | three values added; found by the new test |
| `IOrganizationSwitches.GetOrganizationSwitchPortsTopologyDiscoveryByDeviceAsync(…13 filter params…)` with `[Get(".../switch/ports/usage/history/byDevice/byInterval")]` — a copy of the usage-history method renamed, so it fetched usage history into the topology type | **removed**; the single-parameter overload with the correct `.../topology/discovery/byDevice` path remains. No callers outside `Interfaces`. |

## Verification

```
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s), 6 pre-existing CS0618 warnings
Meraki.Api.Test (Data namespace)        Total: 56, Errors: 0, Failed: 0   (8 new in SwitchCameraSensorCellularMemberTests)
Meraki.Api.Test (Workflows)             Total: 12, Errors: 0, Failed: 0
```

All edited files kept their BOM state.
