### PR TITLE
feat: map the Live Tools and general members from the 1.74.0 gap report

### DIFF
--- a/.github/skills/meraki-api-update/Find-MissingModelMembers.ps1
+++ b/.github/skills/meraki-api-update/Find-MissingModelMembers.ps1
@@ -285,7 +285,9 @@ $grouped = $realFindings |
 	} |
 	Sort-Object ClrType, JsonMember
 
-Write-Information "Unmapped response members: $(@($grouped).Count) across $(@($grouped.ClrType | Sort-Object -Unique).Count) types"
+$groupedList = @($grouped)
+$typeCount = if ($groupedList.Count -eq 0) { 0 } else { @($groupedList | ForEach-Object { $_.ClrType } | Sort-Object -Unique).Count }
+Write-Information "Unmapped response members: $($groupedList.Count) across $typeCount types"
 
 if ($OutCsv) {
 	$grouped | Export-Csv -LiteralPath $OutCsv -NoTypeInformation -Encoding UTF8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ﻿# Changelog
 
+## 1.74.19
+
+- **Nineteen Live Tools and general response members the v1.74.0 spec documents are now mapped**,
+  the sixth and last per-area batch from the gap report, which closes every member it listed:
+  `Client.Cdp`; `ClientProvision.ClientId` and `.Message`; `DeviceClient.AdaptivePolicyGroup` and
+  `.Switchport`; `Mac` on both `DeviceLiveToolsMacTable*ResponseRequest` types; `IpVersion`, `Vrf`
+  and (for interfaces) `VrfType` on `DeviceLiveToolsMulticastRoutingGetResponseInterface` and
+  `…Route`; `Events.ClientMac`; `LiveToolsArpTableResultTableEntry.Interface`;
+  `LiveToolsThroughputTestCreateResponse.ThroughputTestId`; and, alongside the legacy names the
+  models already carry, the API's current `startTime`/`endTime` on `LossAndLatencyHistory` and
+  `received` on `SubclassApplicationUsage` and `SubclassUsageHistory`. Regression tests are in
+  `Meraki.Api.Test.Data.LiveToolsGeneralMemberTests`.
+
+  With this batch, `Find-MissingModelMembers.ps1` reports no unmapped response members against
+  v1.74.0. What remains is the endpoint gap it also reports: 140 spec operations not implemented and
+  214 library endpoints matching no spec path, which need their own pass.
+
 ## 1.74.17
 
 - **Twenty-two Switch, Camera, Sensor and Cellular Gateway response members the v1.74.0 spec

--- a/Meraki.Api.Test/Data/LiveToolsGeneralMemberTests.cs
+++ b/Meraki.Api.Test/Data/LiveToolsGeneralMemberTests.cs
@@ -1,0 +1,80 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Meraki.Api.Test.Data;
+
+/// <summary>
+/// Regression tests for Live Tools and general response members the v1.74.0 OpenAPI spec documents
+/// that the models lacked. Each payload has the shape the spec documents, and is deserialized with
+/// the settings <see cref="JsonMissingMemberHandling.ThrowOnError"/> uses so an unmapped field fails
+/// the test rather than being dropped.
+/// </summary>
+public class LiveToolsGeneralMemberTests
+{
+	private static readonly JsonSerializerSettings ThrowOnMissingMember = new()
+	{
+		NullValueHandling = NullValueHandling.Ignore,
+		MissingMemberHandling = MissingMemberHandling.Error,
+		Converters = [new StringEnumConverter()]
+	};
+
+	private static T Deserialize<T>(string json)
+	{
+		var result = JsonConvert.DeserializeObject<T>(json, ThrowOnMissingMember);
+		_ = result.Should().NotBeNull();
+		return result!;
+	}
+
+	// GET /networks/{networkId}/clients/{clientId} - cdp is a list of two-element lists.
+	[Fact]
+	public void Deserialize_Client_MapsCdp()
+	{
+		var client = Deserialize<Meraki.Api.Data.Client>("""{ "id": "k74272e", "mac": "00:11:22:33:44:55", "cdp": [ [ "Device ID", "sw1" ], [ "Port ID", "Gi1/0/1" ] ] }""");
+
+		_ = client.Cdp.Should().HaveCount(2);
+		_ = client.Cdp![1][1].Should().Be("Gi1/0/1");
+	}
+
+	// POST /networks/{networkId}/clients/provision
+	[Fact]
+	public void Deserialize_ClientProvision_MapsClientIdAndMessage()
+	{
+		var provision = Deserialize<ClientProvision>("""{ "mac": "00:11:22:33:44:55", "name": "Laptop", "clientId": "k74272e", "message": "Blocked by policy" }""");
+
+		_ = provision.ClientId.Should().Be("k74272e");
+		_ = provision.Message.Should().Be("Blocked by policy");
+	}
+
+	// GET /devices/{serial}/livetools/multicastRouting/{multicastRoutingId}
+	[Fact]
+	public void Deserialize_MulticastRoutingInterfaceAndRoute_MapVrfFields()
+	{
+		var iface = Deserialize<DeviceLiveToolsMulticastRoutingGetResponseInterface>("""{ "name": "Vlan10", "ip": "10.0.10.1", "subnet": "10.0.10.0/24", "flags": [], "neighbors": [], "ipVersion": "4", "vrf": "Default", "vrfType": "default" }""");
+		var route = Deserialize<DeviceLiveToolsMulticastRoutingGetResponseRoute>("""{ "group": "239.1.1.1", "incomingInterfaceName": "Vlan10", "rendezvousPoint": "10.0.0.1", "source": "10.0.10.5", "flags": [], "outgoingInterfaceNames": [], "ipVersion": "4", "vrf": "Default" }""");
+
+		_ = iface.VrfType.Should().Be("default");
+		_ = route.Vrf.Should().Be("Default");
+	}
+
+	// GET /devices/{serial}/lossAndLatencyHistory - the API's current names alongside the legacy ones.
+	[Fact]
+	public void Deserialize_LossAndLatencyHistory_MapsCurrentTimeNames()
+	{
+		var sample = Deserialize<LossAndLatencyHistory>("""{ "startTime": "2026-09-09T10:00:00Z", "endTime": "2026-09-09T10:01:00Z", "lossPercent": 0.5, "latencyMs": 12.5, "goodput": 1000, "jitter": 1.5 }""");
+
+		_ = sample.StartTimeUtc.Should().Be(new DateTime(2026, 9, 9, 10, 0, 0, DateTimeKind.Utc));
+	}
+
+	// Remaining scalars across the area.
+	[Fact]
+	public void Deserialize_LiveToolsAndGeneralScalars_Bind()
+	{
+		_ = Deserialize<DeviceClient>("""{ "id": "k74272e", "mac": "00:11:22:33:44:55", "adaptivePolicyGroup": "Employees", "switchport": "1" }""").Switchport.Should().Be("1");
+		_ = Deserialize<DeviceLiveToolsMacTableGetResponseRequest>("""{ "serial": "Q2XX-ABCD-1234", "mac": "00:11:22:a0:b1:c2" }""").Mac.Should().Be("00:11:22:a0:b1:c2");
+		_ = Deserialize<Events>("""{ "occurredAt": "2026-09-09T10:00:00Z", "networkId": "N_1", "type": "association", "description": "802.11 association", "clientMac": "00:11:22:33:44:55" }""").ClientMac.Should().Be("00:11:22:33:44:55");
+		_ = Deserialize<LiveToolsArpTableResultTableEntry>("""{ "vlanId": 10, "ip": "10.0.10.5", "lastUpdatedAt": "2026-09-09T10:00:00Z", "mac": "00:11:22:33:44:55", "interface": "Vlan10" }""").Interface.Should().Be("Vlan10");
+		_ = Deserialize<LiveToolsThroughputTestCreateResponse>("""{ "throughputTestId": "1" }""").ThroughputTestId.Should().Be("1");
+		_ = Deserialize<SubclassApplicationUsage>("""{ "application": "Google", "received": 1024, "sent": 512 }""").Received.Should().Be(1024);
+		_ = Deserialize<SubclassUsageHistory>("""{ "ts": "2026-09-09", "received": 10.5, "sent": 2 }""").Received.Should().Be(10.5);
+	}
+}

--- a/Meraki.Api/Data/Client.cs
+++ b/Meraki.Api/Data/Client.cs
@@ -228,4 +228,11 @@ public class Client : IdentifiedItem
 	/// </summary>
 	[DataMember(Name = "model")]
 	public string? Model { get; set; }
+
+	/// <summary>
+	/// The Cisco Discovery Protocol settings for the client, as the API returns them: a list of name/value pairs, each pair itself a two-element list
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "cdp")]
+	public List<List<string>>? Cdp { get; set; }
 }

--- a/Meraki.Api/Data/ClientProvision.cs
+++ b/Meraki.Api/Data/ClientProvision.cs
@@ -19,4 +19,18 @@ public class ClientProvision
 	[ApiAccess(ApiAccess.Create)]
 	[DataMember(Name = "name")]
 	public string? Name { get; set; }
+
+	/// <summary>
+	/// The identifier of the client
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "clientId")]
+	public string? ClientId { get; set; }
+
+	/// <summary>
+	/// The client's display message if its group policy is 'Blocked'
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "message")]
+	public string? Message { get; set; }
 }

--- a/Meraki.Api/Data/DeviceClient.cs
+++ b/Meraki.Api/Data/DeviceClient.cs
@@ -65,4 +65,18 @@ public class DeviceClient
 	/// </summary>
 	[DataMember(Name = "dhcpHostname")]
 	public string? DhcpHostname { get; set; }
+
+	/// <summary>
+	/// A description of the adaptive policy group
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "adaptivePolicyGroup")]
+	public string? AdaptivePolicyGroup { get; set; }
+
+	/// <summary>
+	/// The name of the switchport with clients on it, if the device is a switch
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "switchport")]
+	public string? Switchport { get; set; }
 }

--- a/Meraki.Api/Data/DeviceLiveToolsMacTableCreateResponseRequest.cs
+++ b/Meraki.Api/Data/DeviceLiveToolsMacTableCreateResponseRequest.cs
@@ -12,4 +12,11 @@ public class DeviceLiveToolsMacTableCreateResponseRequest
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "serial")]
 	public string Serial { get; set; } = string.Empty;
+
+	/// <summary>
+	/// MAC address used to filter MAC table entries. Must be a colon-delimited six-octet MAC address, for example '00:11:22:a0:b1:c2'. Matching is case-insensitive.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadCreate)]
+	[DataMember(Name = "mac")]
+	public string? Mac { get; set; }
 }

--- a/Meraki.Api/Data/DeviceLiveToolsMacTableGetResponseRequest.cs
+++ b/Meraki.Api/Data/DeviceLiveToolsMacTableGetResponseRequest.cs
@@ -12,4 +12,11 @@ public class DeviceLiveToolsMacTableGetResponseRequest
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "serial")]
 	public string Serial { get; set; } = string.Empty;
+
+	/// <summary>
+	/// MAC address used to filter MAC table entries. Must be a colon-delimited six-octet MAC address, for example '00:11:22:a0:b1:c2'. Matching is case-insensitive.
+	/// </summary>
+	[ApiAccess(ApiAccess.ReadCreate)]
+	[DataMember(Name = "mac")]
+	public string? Mac { get; set; }
 }

--- a/Meraki.Api/Data/DeviceLiveToolsMulticastRoutingGetResponseInterface.cs
+++ b/Meraki.Api/Data/DeviceLiveToolsMulticastRoutingGetResponseInterface.cs
@@ -40,4 +40,25 @@ public class DeviceLiveToolsMulticastRoutingGetResponseInterface
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "neighbors")]
 	public List<string> Neighbors { get; set; } = [];
+
+	/// <summary>
+	/// IP version for the interface. Included on networks with IOS XE 17.18 or higher
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "ipVersion")]
+	public string? IpVersion { get; set; }
+
+	/// <summary>
+	/// VRF name for the interface. Included on networks with IOS XE 17.18 or higher
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "vrf")]
+	public string? Vrf { get; set; }
+
+	/// <summary>
+	/// VRF type for the interface. Included on networks with IOS XE 17.18 or higher
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "vrfType")]
+	public string? VrfType { get; set; }
 }

--- a/Meraki.Api/Data/DeviceLiveToolsMulticastRoutingGetResponseRoute.cs
+++ b/Meraki.Api/Data/DeviceLiveToolsMulticastRoutingGetResponseRoute.cs
@@ -47,4 +47,18 @@ public class DeviceLiveToolsMulticastRoutingGetResponseRoute
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "outgoingInterfaceNames")]
 	public List<string> OutgoingInterfaceNames { get; set; } = [];
+
+	/// <summary>
+	/// IP version for the route. Included on networks with IOS XE 17.18 or higher
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "ipVersion")]
+	public string? IpVersion { get; set; }
+
+	/// <summary>
+	/// VRF name for the route. Included on networks with IOS XE 17.18 or higher
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "vrf")]
+	public string? Vrf { get; set; }
 }

--- a/Meraki.Api/Data/Events.cs
+++ b/Meraki.Api/Data/Events.cs
@@ -77,4 +77,11 @@ public class Events
 	/// </summary>
 	[DataMember(Name = "eventData")]
 	public EventData EventData { get; set; } = new();
+
+	/// <summary>
+	/// The client's MAC address.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "clientMac")]
+	public string? ClientMac { get; set; }
 }

--- a/Meraki.Api/Data/LiveToolsArpTableResultTableEntry.cs
+++ b/Meraki.Api/Data/LiveToolsArpTableResultTableEntry.cs
@@ -34,4 +34,11 @@ public class LiveToolsArpTableResultTableEntry
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "mac")]
 	public string Mac { get; set; } = string.Empty;
+
+	/// <summary>
+	/// The interface name of the ARP table entry, such as Vlan1, Port-channel2, or GigabitEthernet1/0/1.
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "interface")]
+	public string? Interface { get; set; }
 }

--- a/Meraki.Api/Data/LiveToolsThroughputTestCreateResponse.cs
+++ b/Meraki.Api/Data/LiveToolsThroughputTestCreateResponse.cs
@@ -55,4 +55,11 @@ public class LiveToolsThroughputTestCreateResponse
 	[ApiAccess(ApiAccess.Read)]
 	[DataMember(Name = "result")]
 	public LiveToolsThroughputTestCreateResponseResult Result { get; set; } = new();
+
+	/// <summary>
+	/// ID of throughput test job
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "throughputTestId")]
+	public string? ThroughputTestId { get; set; }
 }

--- a/Meraki.Api/Data/LossAndLatencyHistory.cs
+++ b/Meraki.Api/Data/LossAndLatencyHistory.cs
@@ -41,4 +41,18 @@ public class LossAndLatencyHistory
 	/// </summary>
 	[DataMember(Name = "jitter")]
 	public double Jitter { get; set; }
+
+	/// <summary>
+	/// Start time of the sample, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "startTime")]
+	public DateTime? StartTimeUtc { get; set; }
+
+	/// <summary>
+	/// End time of the sample, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "endTime")]
+	public DateTime? EndTimeUtc { get; set; }
 }

--- a/Meraki.Api/Data/SubclassApplicationUsage.cs
+++ b/Meraki.Api/Data/SubclassApplicationUsage.cs
@@ -23,4 +23,11 @@ public class SubclassApplicationUsage
 	/// </summary>
 	[DataMember(Name = "sent")]
 	public int Sent { get; set; }
+
+	/// <summary>
+	/// Total bytes received by the client for the application, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "received")]
+	public long? Received { get; set; }
 }

--- a/Meraki.Api/Data/SubclassUsageHistory.cs
+++ b/Meraki.Api/Data/SubclassUsageHistory.cs
@@ -23,4 +23,11 @@ public class SubclassUsageHistory
 	/// </summary>
 	[DataMember(Name = "sent")]
 	public int Sent { get; set; }
+
+	/// <summary>
+	/// Usage received by the client on a given day, as the current API names it
+	/// </summary>
+	[ApiAccess(ApiAccess.Read)]
+	[DataMember(Name = "received")]
+	public double? Received { get; set; }
 }


### PR DESCRIPTION
## Stacked on #421 → #420 → #419 → #418 → #417 → #416 → #415

Base is `feat/map-switch-camera-sensor-cellular-members`. Merge the chain in order with merge commits, then retarget this to `main`. Changelog label `1.74.19` assumes that.

## What

Sixth and **last** per-area batch from `gap-report-v1.74.0.md`: **19 Live Tools and general members**, all scalars except `Client.Cdp`.

| Model | Added |
|---|---|
| `Client` | `Cdp` — `List<List<string>>?`, the API returns CDP as a list of two-element name/value lists |
| `ClientProvision` | `ClientId`, `Message` |
| `DeviceClient` | `AdaptivePolicyGroup`, `Switchport` |
| `DeviceLiveToolsMacTable{Create,Get}ResponseRequest` | `Mac` |
| `DeviceLiveToolsMulticastRoutingGetResponse{Interface,Route}` | `IpVersion`, `Vrf` (+ `VrfType` on the interface) |
| `Events` | `ClientMac` |
| `LiveToolsArpTableResultTableEntry` | `Interface` |
| `LiveToolsThroughputTestCreateResponse` | `ThroughputTestId` |
| `LossAndLatencyHistory`, `SubclassApplicationUsage`, `SubclassUsageHistory` | the API's current `startTime`/`endTime`/`received` **alongside** the legacy `startTs`/`endTs`/`recv` — as with `Wifi` in #420, I don't know which set the live API sends, so nothing was removed |

## Where this leaves the gap report

After this chain merges, `Find-MissingModelMembers.ps1` reports **0 unmapped response members** against v1.74.0 (from 155). What it still reports, and what this series did not touch:

- **140 spec operations not implemented** (new endpoints).
- **214 library endpoints matching no spec path** — some removed/renamed by Cisco, some path shapes the normaliser misses, some possibly dead code.

Both need their own pass; the ApiChecker project is the existing tool for the endpoint side.

## Verification

```
dotnet build Meraki.Api.slnx -c Debug   Build succeeded, 0 Error(s)
Meraki.Api.Test (Data namespace)        Total: 61, Errors: 0, Failed: 0   (5 new in LiveToolsGeneralMemberTests)
Meraki.Api.Test (Workflows)             Total: 12, Errors: 0, Failed: 0
```

All 13 edited files kept their BOM state.
